### PR TITLE
Simplify calculateSkillCost signature with context object

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -3,13 +3,9 @@ import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { Worker } from 'node:worker_threads'
 import { cpus } from 'node:os'
-import {
-    type RaceParameters,
-    GroundCondition,
-    Grade,
-    type Mood,
-    Time,
-    Season,
+import type {
+    RaceParameters,
+    Mood,
 } from '../uma-tools/uma-skill-tools/RaceParameters'
 import {
     HorseState as HorseStateBase,
@@ -18,6 +14,10 @@ import {
 import { ThresholdStat } from '../uma-tools/uma-skill-tools/CourseData'
 import type { SkillMeta, RawCourseData } from './types'
 import {
+    Grade,
+    GroundCondition,
+    Season,
+    Time,
     parseGroundCondition,
     parseWeather,
     parseSeason,

--- a/utils.test.ts
+++ b/utils.test.ts
@@ -1,15 +1,15 @@
 import { describe, it, expect } from 'vitest'
 import {
-    GroundCondition,
-    Season,
-} from '../uma-tools/uma-skill-tools/RaceParameters'
-import {
     DistanceType,
     Surface,
     Orientation,
     type ThresholdStat,
 } from '../uma-tools/uma-skill-tools/CourseData'
 import {
+    Grade,
+    GroundCondition,
+    Season,
+    Time,
     parseGroundCondition,
     parseWeather,
     parseSeason,
@@ -47,6 +47,43 @@ import {
     type CurrentSettings,
     type SkillDataEntry,
 } from './utils'
+
+// Tests to ensure local enum values match upstream uma-tools/uma-skill-tools/RaceParameters.ts
+describe('enum values match upstream', () => {
+    it('Grade values match RaceParameters', () => {
+        expect(Grade.G1).toBe(100)
+        expect(Grade.G2).toBe(200)
+        expect(Grade.G3).toBe(300)
+        expect(Grade.OP).toBe(400)
+        expect(Grade.PreOP).toBe(700)
+        expect(Grade.Maiden).toBe(800)
+        expect(Grade.Debut).toBe(900)
+        expect(Grade.Daily).toBe(999)
+    })
+
+    it('GroundCondition values match RaceParameters', () => {
+        expect(GroundCondition.Good).toBe(1)
+        expect(GroundCondition.Yielding).toBe(2)
+        expect(GroundCondition.Soft).toBe(3)
+        expect(GroundCondition.Heavy).toBe(4)
+    })
+
+    it('Season values match RaceParameters', () => {
+        expect(Season.Spring).toBe(1)
+        expect(Season.Summer).toBe(2)
+        expect(Season.Autumn).toBe(3)
+        expect(Season.Winter).toBe(4)
+        expect(Season.Sakura).toBe(5)
+    })
+
+    it('Time values match RaceParameters', () => {
+        expect(Time.NoTime).toBe(0)
+        expect(Time.Morning).toBe(1)
+        expect(Time.Midday).toBe(2)
+        expect(Time.Evening).toBe(3)
+        expect(Time.Night).toBe(4)
+    })
+})
 
 describe('parseGroundCondition', () => {
     it.each([
@@ -676,11 +713,11 @@ describe('calculateStatsFromRawResults', () => {
 describe('calculateSkillCost', () => {
     const skillMeta: Record<
         string,
-        { baseCost: number; groupId?: number; order?: number }
+        { baseCost: number; groupId?: string; order?: number }
     > = {
         skill001: { baseCost: 200 },
-        skill002: { baseCost: 150, groupId: 1, order: 1 },
-        skill003: { baseCost: 100, groupId: 1, order: 2 },
+        skill002: { baseCost: 150, groupId: '1', order: 1 },
+        skill003: { baseCost: 100, groupId: '1', order: 2 },
     }
     const context = { skillMeta }
 

--- a/utils.ts
+++ b/utils.ts
@@ -1,8 +1,13 @@
 // Local constants mirroring const enum values (const enums aren't exported at runtime)
-const GroundCondition = { Good: 1, Heavy: 4, Soft: 3, Yielding: 2 } as const
-type GroundCondition = (typeof GroundCondition)[keyof typeof GroundCondition]
-const Season = { Autumn: 3, Sakura: 5, Spring: 1, Summer: 2, Winter: 4 } as const
-type Season = (typeof Season)[keyof typeof Season]
+// Values must match ../uma-tools/uma-skill-tools/RaceParameters.ts
+export const Grade = { Daily: 999, Debut: 900, G1: 100, G2: 200, G3: 300, Maiden: 800, OP: 400, PreOP: 700 } as const
+export type Grade = (typeof Grade)[keyof typeof Grade]
+export const GroundCondition = { Good: 1, Heavy: 4, Soft: 3, Yielding: 2 } as const
+export type GroundCondition = (typeof GroundCondition)[keyof typeof GroundCondition]
+export const Season = { Autumn: 3, Sakura: 5, Spring: 1, Summer: 2, Winter: 4 } as const
+export type Season = (typeof Season)[keyof typeof Season]
+export const Time = { Evening: 3, Midday: 2, Morning: 1, Night: 4, NoTime: 0 } as const
+export type Time = (typeof Time)[keyof typeof Time]
 import type {
     DistanceType,
     Surface,
@@ -404,7 +409,7 @@ export function calculateStatsFromRawResults(
 export interface SkillCostContext {
     skillMeta: Record<
         string,
-        { baseCost: number; groupId?: number; order?: number }
+        { baseCost: number; groupId?: string; order?: number }
     >
     baseUmaSkillIds?: string[]
     skillNames?: Record<string, string[]>


### PR DESCRIPTION
## Summary
- Reduce `calculateSkillCost` parameter count from 8 to 3
- Create `SkillCostContext` interface to group related parameters
- Update call site in `cli.ts` to construct context object
- Define const enums locally to fix tsx/esbuild import issues (fixes CLI/build issues)
- Update tests to use the new signature and verify enum values

## Test plan
- [x] All 129 unit tests pass (`npm test`)
- [x] CLI works correctly with pre-built JavaScript (`node cli.js AT_Med.json`)

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)