### PR TITLE
Rename project to umalator

### DIFF
--- a/.cursor/rules/umalator-global-cli.mdc
+++ b/.cursor/rules/umalator-global-cli.mdc
@@ -1,8 +1,0 @@
----
-alwaysApply: true
----
-# Umalator Global CLI
-
-In this project, you are developing a CLI tool for evaluating skills. It is in `/umalator-global-cli`. Use the already implemented tools in this repository, but try to limit the amount of changes you make to them.
-
-If looking at code, limit yourself to the files in `/umalator-global-cli` as well, unless you are stuck or specifically asked to look at other files.

--- a/.cursor/rules/umalator.mdc
+++ b/.cursor/rules/umalator.mdc
@@ -1,0 +1,8 @@
+---
+alwaysApply: true
+---
+# Umalator
+
+In this project, you are developing a web interface for Uma Musume skill efficiency calculations. It is in `/umalator`. Use the already implemented tools in this repository, but try to limit the amount of changes you make to them.
+
+If looking at code, limit yourself to the files in `/umalator` as well, unless you are stuck or specifically asked to look at other files.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Web interface for evaluating skills in umalator-global. Calculates mean length gains for skills and outputs results sorted by efficiency (mean length / cost).
+Web interface for Uma Musume skill efficiency calculations. Calculates mean length gains for skills and outputs results sorted by efficiency (mean length / cost).
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# umalator-global-cli
+# Umalator
 
-Web interface for evaluating skills in umalator-global. It calculates mean length gains for skills and outputs a table sorted by efficiency (mean length / cost).
+Web interface for Uma Musume skill efficiency calculations. It calculates mean length gains for skills and outputs a table sorted by efficiency (mean length / cost).
 
 Note: The results are different from the browser version, as all optional options are turned on in `simOptions` (unless `deterministic` is set to `true`).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,13 @@
 {
-  "name": "umalator-global-cli",
+  "name": "umalator",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "umalator-global-cli",
+      "name": "umalator",
       "version": "1.0.0",
       "dependencies": {
-        "commander": "^11.0.0",
         "esbuild": "^0.27.2",
         "express": "^4.18.0",
         "immutable": "^4.3.0"
@@ -1844,15 +1843,6 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/commander": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
-      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
-      }
     },
     "node_modules/concurrently": {
       "version": "9.2.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
-  "name": "umalator-global-cli",
+  "name": "umalator",
+  "description": "Web interface for Uma Musume skill efficiency calculations",
   "version": "1.0.0",
   "type": "module",
   "scripts": {

--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <title>Umalator Global CLI - Web Interface</title>
+        <title>Umalator - Uma Musume Skill Calculator</title>
 
         <script type="module" crossorigin src="/app.js"></script>
         <link rel="stylesheet" crossorigin href="/index.css" />

--- a/types.ts
+++ b/types.ts
@@ -1,5 +1,5 @@
 /**
- * Type definitions for umalator-global-cli.
+ * Type definitions for umalator.
  * These types replace `any` usages for better type safety.
  */
 


### PR DESCRIPTION
## Summary

- Rename project from `umalator-global-cli` to `umalator`
- The project has evolved from CLI-focused to web-first, and the name now reflects this
- Updates package.json, README, CLAUDE.md, page title, cursor rules, and type definitions

## Manual Steps After Merge

1. **Rename GitHub repository** via Settings > General
2. Update local git remote: `git remote set-url origin git@github.com:Martin-Milbradt/umalator.git`
3. Optionally rename local directory

Closes #37

## Test plan

- [x] `npm run build` succeeds
- [x] `npm run build:frontend` succeeds  
- [x] `npm test` passes (244 tests)

🤖 Generated with [Claude Code](https://claude.ai/code)