### PR TITLE
Fix Flash Forward not recognized as Medium Straightaways upgrade

### DIFF
--- a/utils.test.ts
+++ b/utils.test.ts
@@ -560,6 +560,53 @@ describe('findSkillVariantsByName', () => {
             { skillId: 'skill001', skillName: 'Victoria por Plancha ☆' },
         ])
     })
+
+    it('includes upgraded variants from the same group via groupId', () => {
+        const names: Record<string, string[]> = {
+            '201101': ['Medium Straightaways ◎'],
+            '201102': ['Medium Straightaways ○'],
+            '201103': ['Flash Forward'],
+        }
+        const meta: Record<
+            string,
+            { baseCost: number; groupId?: string; order?: number }
+        > = {
+            '201101': { baseCost: 110, groupId: '20110', order: 20300 },
+            '201102': { baseCost: 100, groupId: '20110', order: 20310 },
+            '201103': { baseCost: 150, groupId: '20110', order: 20290 },
+        }
+        const result = findSkillVariantsByName(
+            'Medium Straightaways',
+            names,
+            meta,
+        )
+        expect(result).toHaveLength(3)
+        const skillNames = result.map((v) => v.skillName)
+        expect(skillNames).toContain('Medium Straightaways ◎')
+        expect(skillNames).toContain('Medium Straightaways ○')
+        expect(skillNames).toContain('Flash Forward')
+    })
+
+    it('excludes × debuff variants from groupId expansion', () => {
+        const names: Record<string, string[]> = {
+            '201101': ['Skill ◎'],
+            '201102': ['Skill ○'],
+            '201103': ['Upgraded Skill'],
+            '201104': ['Skill ×'],
+        }
+        const meta: Record<
+            string,
+            { baseCost: number; groupId?: string; order?: number }
+        > = {
+            '201101': { baseCost: 110, groupId: '20110', order: 20300 },
+            '201102': { baseCost: 100, groupId: '20110', order: 20310 },
+            '201103': { baseCost: 150, groupId: '20110', order: 20290 },
+            '201104': { baseCost: 100, groupId: '20110', order: 20320 },
+        }
+        const result = findSkillVariantsByName('Skill', names, meta)
+        expect(result).toHaveLength(3)
+        expect(result.map((v) => v.skillName)).not.toContain('Skill ×')
+    })
 })
 
 describe('processCourseData', () => {

--- a/utils.ts
+++ b/utils.ts
@@ -320,7 +320,10 @@ export function findSkillIdByNameWithPreference(
 export function findSkillVariantsByName(
     baseSkillName: string,
     skillNames: Record<string, string[]>,
-    skillMeta: Record<string, { baseCost: number }>,
+    skillMeta: Record<
+        string,
+        { baseCost: number; groupId?: string; order?: number }
+    >,
 ): Array<{ skillId: string; skillName: string }> {
     const variants: Array<{ skillId: string; skillName: string }> = []
     const trimmedBaseName = baseSkillName.trim()
@@ -344,6 +347,7 @@ export function findSkillVariantsByName(
         }
     }
 
+    const groupIds = new Set<string>()
     for (const [id, names] of Object.entries(skillNames)) {
         const name = names[0]
         const normalizedName = name.toLowerCase()
@@ -351,9 +355,31 @@ export function findSkillVariantsByName(
             normalizedName === `${normalizedBaseName} ○` ||
             normalizedName === `${normalizedBaseName} ◎`
         ) {
-            const baseCost = skillMeta[id]?.baseCost ?? 200
+            const meta = skillMeta[id]
+            const baseCost = meta?.baseCost ?? 200
             if (baseCost > 0) {
                 variants.push({ skillId: id, skillName: name })
+                if (meta?.groupId) {
+                    groupIds.add(meta.groupId)
+                }
+            }
+        }
+    }
+
+    // Include upgraded variants from the same group (e.g. Flash Forward for Medium Straightaways)
+    const variantIds = new Set(variants.map((v) => v.skillId))
+    for (const groupId of groupIds) {
+        for (const [id, meta] of Object.entries(skillMeta)) {
+            if (
+                meta.groupId === groupId &&
+                !variantIds.has(id) &&
+                (meta.baseCost ?? 200) > 0
+            ) {
+                const names = skillNames[id]
+                if (names?.[0] && !names[0].endsWith(' ×')) {
+                    variants.push({ skillId: id, skillName: names[0] })
+                    variantIds.add(id)
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

- `findSkillVariantsByName` now uses `groupId` to discover upgraded variants with different names (e.g. "Flash Forward" for "Medium Straightaways")
- Previously the function only found variants via ○/◎ name suffixes, missing upgrades that have entirely different names
- Excludes × debuff variants from the groupId expansion
- Added two tests: groupId-based upgrade discovery and × exclusion

Issue: #48

## Test plan

- [x] All 258 existing tests pass
- [x] Type check passes (only pre-existing uma-tools errors)
- [ ] Verify in browser: add "Medium Straightaways" to a config, run simulation, confirm Flash Forward appears in results
- [ ] Verify Flash Forward cost calculation includes prerequisite skill costs