### PR TITLE
Skip skills missing from skill_meta in variant resolution

### DIFF
--- a/utils.test.ts
+++ b/utils.test.ts
@@ -560,6 +560,32 @@ describe('findSkillVariantsByName', () => {
             { skillId: 'skill001', skillName: 'Victoria por Plancha ☆' },
         ])
     })
+
+    it('excludes skills that exist in skillNames but not in skillMeta', () => {
+        const names: Record<string, string[]> = {
+            skill001: ['Eager'],
+        }
+        const meta: Record<string, { baseCost: number }> = {}
+        const result = findSkillVariantsByName('Eager', names, meta)
+        expect(result).toEqual([])
+    })
+
+    it('excludes ○/◎ variants missing from skillMeta', () => {
+        const names: Record<string, string[]> = {
+            skill001: ['Test Skill', 'テスト'],
+            skill002: ['Test Skill ○'],
+            skill003: ['Test Skill ◎'],
+        }
+        const meta: Record<string, { baseCost: number }> = {
+            skill001: { baseCost: 0 },
+            skill002: { baseCost: 100 },
+            // skill003 intentionally missing from meta
+        }
+        const result = findSkillVariantsByName('Test Skill', names, meta)
+        expect(result).toEqual([
+            { skillId: 'skill002', skillName: 'Test Skill ○' },
+        ])
+    })
 })
 
 describe('processCourseData', () => {

--- a/utils.ts
+++ b/utils.ts
@@ -333,8 +333,8 @@ export function findSkillVariantsByName(
         true,
     )
     if (exactMatchId) {
-        const baseCost = skillMeta[exactMatchId]?.baseCost ?? 200
-        if (baseCost > 0) {
+        const meta = skillMeta[exactMatchId]
+        if (meta && meta.baseCost > 0) {
             const canonicalName = skillNames[exactMatchId][0]
             variants.push({
                 skillId: exactMatchId,
@@ -351,8 +351,8 @@ export function findSkillVariantsByName(
             normalizedName === `${normalizedBaseName} ○` ||
             normalizedName === `${normalizedBaseName} ◎`
         ) {
-            const baseCost = skillMeta[id]?.baseCost ?? 200
-            if (baseCost > 0) {
+            const meta = skillMeta[id]
+            if (meta && meta.baseCost > 0) {
                 variants.push({ skillId: id, skillName: name })
             }
         }


### PR DESCRIPTION
## Summary

- `findSkillVariantsByName` now requires skills to exist in `skillMeta` before returning them as variants
- Previously, missing metadata defaulted `baseCost` to 200 via `?? 200`, making skills like "Eager" (202102) appear valid despite having no simulation data
- This affects 99 skills in `skillnames.json` that lack entries in `skill_meta.json` (inherited skills, scenario skills, and newer skills like Eager/Elated/Burning Soul)
- Added two tests: exact match missing from meta, and ○/◎ variant missing from meta

Issue: #49

## Test plan

- [x] All 258 tests pass
- [x] Type check passes (only pre-existing uma-tools errors)
- [ ] Add "Eager" to a config, run simulation, confirm it's cleanly skipped (no error, not in results)
- [ ] Verify existing skills with metadata still resolve and simulate correctly