### PR TITLE
Fetch latest game data at build time

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,14 +27,6 @@ jobs:
       - name: Pin uma-skill-tools to otherHorse commit
         run: cd uma-tools/uma-skill-tools && git fetch origin 24f0a8862106dd4aaeea55e90e975acc9ca5d019 && git checkout 24f0a8862106dd4aaeea55e90e975acc9ca5d019
 
-      - name: Fetch latest game data from upstream uma-tools
-        run: |
-          cd uma-tools
-          git fetch origin master
-          git show origin/master:umalator-global/skill_data.json > umalator-global/skill_data.json
-          git show origin/master:umalator-global/skill_meta.json > umalator-global/skill_meta.json
-          git show origin/master:skill_meta.json > skill_meta.json
-
       - uses: actions/setup-node@v4
         with:
           node-version: 22

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ npx tsx race-check.ts --races path/to/races.json --sims 200
 - `simulation.browser-worker.ts` - Thin Web Worker entry point for browser builds
 - `cli.ts` - CLI entry point: loads data at runtime, runs `SimulationRunner`, outputs JSON
 - `simulation-runner.ts` - Node worker orchestration (used by `cli.ts` and `server.ts`)
-- `build.ts` - esbuild config: bundles Node worker + browser worker, copies data files to `static/data/`
+- `build.ts` - esbuild config: bundles Node worker + browser worker, fetches latest game data from upstream uma-tools, copies data files to `static/data/`
 - `utils.ts` - Pure utility functions for parsing, formatting, statistics, and skill resolution
 - `types.ts` - Shared type definitions (worker messages, simulation tasks, skill metadata)
 
@@ -87,16 +87,17 @@ npx tsx race-check.ts --races path/to/races.json --sims 200
 ### Build Pipeline
 
 - `npm run build` runs `tsx build.ts` which:
-  1. Copies 5 JSON data files from `uma-tools/umalator-global/` to `static/data/`
-  2. Builds Node worker (`simulation.worker.js` in repo root)
-  3. Builds browser worker (`static/simulation.browser-worker.js`)
+  1. Fetches latest `skill_data.json` and `skill_meta.json` from upstream uma-tools (falls back to local files offline)
+  2. Copies 5 JSON data files from `uma-tools/umalator-global/` to `static/data/`
+  3. Builds Node worker (`simulation.worker.js` in repo root)
+  4. Builds browser worker (`static/simulation.browser-worker.js`)
 - `npm run build:frontend` runs `vite build` which bundles `public/` into `dist/`
 - `static/` is Vite's publicDir (configured in `vite.config.ts`) - files are copied as-is to `dist/`
 - GitHub Pages deploy sets `VITE_BASE=/umalator/` so asset paths resolve correctly
 
 ### Static vs Runtime Data
 
-- **Browser** uses bundled data files in `static/data/` (copied at build time). Data is stale until `npm run build` re-copies from uma-tools.
+- **Browser** uses bundled data files in `static/data/` (copied at build time). `npm run build` fetches latest game data from upstream automatically.
 - **CLI** loads data from `uma-tools/umalator-global/` at runtime, so it always reflects current skill data without rebuilding.
 
 ## Key Patterns

--- a/build.ts
+++ b/build.ts
@@ -1,5 +1,6 @@
 import * as esbuild from 'esbuild'
-import { copyFileSync, existsSync, mkdirSync, readFileSync } from 'node:fs'
+import { execSync } from 'node:child_process'
+import { copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import * as path from 'node:path'
 
 const root = path.join(import.meta.dirname, 'uma-tools')
@@ -236,7 +237,31 @@ function copyDataFiles(): void {
     }
 }
 
+// Fetch latest game data from upstream uma-tools (mirrors CI behavior).
+// Falls back to local files on network failure.
+function fetchLatestGameData(): void {
+    const dataFiles = [
+        'umalator-global/skill_data.json',
+        'umalator-global/skill_meta.json',
+        'skill_meta.json',
+    ]
+    try {
+        execSync('git fetch origin master', { cwd: root, stdio: 'pipe' })
+        for (const file of dataFiles) {
+            const content = execSync(`git show origin/master:${file}`, {
+                cwd: root,
+                maxBuffer: 10 * 1024 * 1024,
+            })
+            writeFileSync(path.join(root, file), content)
+        }
+        console.log('Fetched latest game data from upstream uma-tools')
+    } catch {
+        console.log('Could not fetch latest game data, using local files')
+    }
+}
+
 try {
+    fetchLatestGameData()
     copyDataFiles()
     await Promise.all([
         esbuild.build(workerBuildOptions),


### PR DESCRIPTION
## Summary

- `build.ts` now fetches the latest `skill_data.json` and `skill_meta.json` from upstream uma-tools before copying data files, matching CI behavior
- Falls back gracefully to local files when offline
- Removes the redundant fetch step from the CI deploy workflow (build.ts handles it now)
- Fixes "Eager" and other recently added skills being unavailable in local dev

Issue: #49

## Test plan

- [x] All 256 tests pass
- [x] Build prints "Fetched latest game data from upstream uma-tools" on success
- [ ] Build falls back gracefully when offline ("Could not fetch latest game data, using local files")
- [ ] Verify "Eager" appears and works in simulations at localhost:5173
- [ ] CI deploy still works (fetch moved from workflow to build.ts)