### PR TITLE
Fix prerequisite cost for 3-level skill upgrades

### DIFF
--- a/discount-variants.test.ts
+++ b/discount-variants.test.ts
@@ -1,0 +1,131 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+    buildSkillNameLookup,
+    buildVariantCache,
+    getDiscountVariants,
+} from './public/skillHelpers'
+import { setDiscountForVariants } from './public/skillsUI'
+import {
+    getCalculatedResultsCache,
+    getCurrentConfig,
+    getResultsMap,
+    setCurrentConfig,
+    setSkillmeta,
+    setSkillNameToId,
+    setSkillnames,
+} from './public/state'
+
+vi.stubGlobal('document', {
+    getElementById: () => null,
+})
+
+// Late Surger Savvy is a ○/◎ pair with no gold upgrade — the scenario the
+// user reported: setting a discount on one variant should register both.
+const NORMAL = 'Late Surger Savvy ○'
+const RARE = 'Late Surger Savvy ◎'
+
+describe('getDiscountVariants', () => {
+    beforeAll(() => {
+        setSkillmeta({
+            '201541': { baseCost: 130, groupId: '20154', order: 21180 },
+            '201542': { baseCost: 110, groupId: '20154', order: 21190 },
+        })
+        setSkillnames({
+            '201541': [RARE],
+            '201542': [NORMAL],
+        })
+        setSkillNameToId({
+            [RARE]: '201541',
+            [NORMAL]: '201542',
+        })
+        buildSkillNameLookup()
+        buildVariantCache()
+    })
+
+    it('returns both siblings regardless of which one is passed', () => {
+        expect(getDiscountVariants(NORMAL).sort()).toEqual([NORMAL, RARE].sort())
+        expect(getDiscountVariants(RARE).sort()).toEqual([NORMAL, RARE].sort())
+    })
+
+    it('always includes the input skill first', () => {
+        expect(getDiscountVariants(NORMAL)[0]).toBe(NORMAL)
+        expect(getDiscountVariants(RARE)[0]).toBe(RARE)
+    })
+})
+
+describe('setDiscountForVariants propagates to results map', () => {
+    beforeAll(() => {
+        setSkillmeta({
+            '201541': { baseCost: 130, groupId: '20154', order: 21180 },
+            '201542': { baseCost: 110, groupId: '20154', order: 21190 },
+        })
+        setSkillnames({
+            '201541': [RARE],
+            '201542': [NORMAL],
+        })
+        setSkillNameToId({
+            [RARE]: '201541',
+            [NORMAL]: '201542',
+        })
+        buildSkillNameLookup()
+        buildVariantCache()
+    })
+
+    beforeEach(() => {
+        setCurrentConfig({
+            skills: {
+                [NORMAL]: { discount: null },
+                [RARE]: { discount: null },
+            },
+            uma: { skills: [] },
+        })
+        getResultsMap().clear()
+        getCalculatedResultsCache().clear()
+    })
+
+    it('adding a discount to ○ registers a pending result for BOTH ○ and ◎', () => {
+        // Regression test: before the fix, only the clicked skill got a pending
+        // entry in the results map. ◎'s config was updated but no row was shown
+        // until "Run Calculations" was clicked.
+        setDiscountForVariants(NORMAL, 10)
+
+        const results = getResultsMap()
+        expect(results.get(NORMAL)?.status).toBe('pending')
+        expect(results.get(RARE)?.status).toBe('pending')
+    })
+
+    it('propagates the discount to both variants in config', () => {
+        setDiscountForVariants(RARE, 20)
+        const config = getCurrentConfig()
+        expect(config?.skills[NORMAL]?.discount).toBe(20)
+        expect(config?.skills[RARE]?.discount).toBe(20)
+    })
+
+    it('clearing the discount removes BOTH entries from the results map', () => {
+        setDiscountForVariants(NORMAL, 10)
+        setDiscountForVariants(NORMAL, null)
+
+        const results = getResultsMap()
+        expect(results.has(NORMAL)).toBe(false)
+        expect(results.has(RARE)).toBe(false)
+    })
+
+    it('changing the discount updates cost without re-queueing a sim', () => {
+        // Seed a cached result so the existing-entry path runs.
+        setDiscountForVariants(NORMAL, 10)
+        // Promote both to fresh as if a sim had returned.
+        for (const skill of [NORMAL, RARE]) {
+            const entry = getResultsMap().get(skill)
+            if (entry) entry.status = 'fresh'
+        }
+
+        setDiscountForVariants(NORMAL, 20)
+
+        const results = getResultsMap()
+        // Both are still present and still marked fresh; only cost/discount update.
+        expect(results.get(NORMAL)?.status).toBe('fresh')
+        expect(results.get(RARE)?.status).toBe('fresh')
+        expect(results.get(NORMAL)?.discount).toBe(20)
+        expect(results.get(RARE)?.discount).toBe(20)
+    })
+})

--- a/public/resultsUI.ts
+++ b/public/resultsUI.ts
@@ -2,12 +2,10 @@ import { autoSave } from './configManager'
 import { callRenderSkills, callRenderUma } from './renderCallbacks'
 import {
     findSkillId,
-    getBasicVariant,
     getGroupVariantOnUma,
     getSkillCostWithDiscount,
     getSkillIconUrl,
     getSkillOrder,
-    getUpgradedVariant,
     isSkillOnUma,
     umaHasUpgradedVersion,
 } from './skillHelpers'
@@ -329,14 +327,6 @@ export function addSkillToUmaFromTable(skillName: string, cost: number): void {
             currentConfig.uma.skillPoints += existingCost
         }
 
-        // If existing was basic (higher order) and we're adding upgraded (lower order)
-        // The basic stays hidden, no need to return to table
-        // If existing was upgraded and we're adding basic, return upgraded to table
-        if (existingVariantOrder < newSkillOrder) {
-            // Existing is upgraded, new is basic - return upgraded to table with full stats
-            void returnSkillToResultsTable(existingVariant)
-        }
-
         // Replace the existing variant with the new skill
         const idx = currentConfig.uma.skills.indexOf(existingVariant)
         if (idx !== -1) {
@@ -355,22 +345,7 @@ export function addSkillToUmaFromTable(skillName: string, cost: number): void {
         currentConfig.uma.skillPoints -= cost
     }
 
-    // Update upgraded skill stats if adding basic skill (show incremental)
-    const basicVariant = getBasicVariant(skillName)
-    if (!basicVariant) {
-        // This is a basic skill (or has no variants), update upgraded skills
-        updateUpgradedSkillsForBasicSkill(skillName)
-    }
-
-    // Remove from results table
-    resultsMap.delete(skillName)
-    selectedSkills.delete(skillName)
-
-    // If adding upgraded skill, also hide basic from results
-    if (basicVariant) {
-        resultsMap.delete(basicVariant)
-        selectedSkills.delete(basicVariant)
-    }
+    refreshGroupResults(skillName)
 
     // Re-render
     refreshResultsCosts()
@@ -396,21 +371,7 @@ export function removeSkillFromUma(skillName: string): void {
         currentConfig.uma.skillPoints += skillCost
     }
 
-    // Return skill to results table (if it has a discount)
-    void returnSkillToResultsTable(skillName)
-
-    // Check if this was a basic skill - if so, restore upgraded skill full stats
-    const upgradedVariant = getUpgradedVariant(skillName)
-    if (upgradedVariant) {
-        // This is a basic skill (has an upgraded variant), restore upgraded skills
-        restoreUpgradedSkillsForBasicSkill(skillName)
-    }
-
-    // If this was an upgraded skill, also show basic skill in results again
-    const basicVariant = getBasicVariant(skillName)
-    if (basicVariant) {
-        void returnSkillToResultsTable(basicVariant)
-    }
+    refreshGroupResults(skillName)
 
     // Refresh costs since Uma skills changed
     refreshResultsCosts()
@@ -472,74 +433,56 @@ export function refreshResultsCosts(): void {
 }
 
 /**
- * When a basic skill is added/removed from Uma, mark upgraded skills for recalculation.
- * The frontend cache is keyed only by skill name (not Uma state), so we must invalidate it.
- * The server-side cache IS keyed by config hash (including Uma skills) and will return
- * fresh results for the new Uma state.
+ * Refresh the results table for every sibling in `skillName`'s group after a change
+ * to `currentConfig.uma.skills`. Call *after* updating `uma.skills`; reads the
+ * updated state to decide what should be shown.
+ *
+ * For each group member:
+ *   - Invalidate the frontend cache. It is keyed only by skill name, so any change
+ *     to the Uma's skills can invalidate the baseline the cached result was
+ *     simulated against.
+ *   - If the sibling is now on Uma or dominated by a more-upgraded Uma skill, leave
+ *     it out of the results map. The renderResultsTable filter hides such entries
+ *     anyway; skipping them here avoids a wasted re-simulation.
+ *   - Otherwise, ensure the sibling is in the results map via
+ *     `returnSkillToResultsTable`, which hydrates from cache or marks it pending.
+ *
+ * Safe to call on a skill with no group (no-op) and on a skill being added to or
+ * removed from Uma (the skill itself is treated like any other sibling).
  */
-export function recalculateUpgradedSkillsForBasicChange(
-    basicSkillName: string,
-): void {
+export function refreshGroupResults(skillName: string): void {
     const skillmeta = getSkillmeta()
     const skillnames = getSkillnames()
-    const currentConfig = getCurrentConfig()
     const calculatedResultsCache = getCalculatedResultsCache()
     const resultsMap = getResultsMap()
+    const selectedSkills = getSelectedSkills()
 
-    if (!skillmeta || !skillnames || !currentConfig?.skills) return
+    if (!skillmeta || !skillnames) return
 
-    const basicSkillId = findSkillId(basicSkillName)
-    if (!basicSkillId) return
+    const skillId = findSkillId(skillName)
+    if (!skillId) return
 
-    const basicMeta = skillmeta[basicSkillId]
-    if (!basicMeta?.groupId) return
+    const groupId = skillmeta[skillId]?.groupId
+    if (!groupId) {
+        calculatedResultsCache.delete(skillName)
+        return
+    }
 
-    const basicGroupId = basicMeta.groupId
-    const basicOrder = basicMeta.order ?? 0
+    for (const [siblingId, siblingMeta] of Object.entries(skillmeta)) {
+        if (siblingMeta.groupId !== groupId) continue
+        const siblingName = skillnames[siblingId]?.[0]
+        if (!siblingName) continue
 
-    // Find upgraded skills (lower order = upgraded) in the same group
-    for (const [upgradedSkillId, upgradedMeta] of Object.entries(skillmeta)) {
-        if (
-            upgradedMeta.groupId === basicGroupId &&
-            (upgradedMeta.order ?? 0) < basicOrder
-        ) {
-            const upgradedSkillNames = skillnames[upgradedSkillId]
-            if (!upgradedSkillNames) continue
+        calculatedResultsCache.delete(siblingName)
 
-            const upgradedSkillName = upgradedSkillNames[0]
-
-            // Only recalculate if the skill has a discount (is in the skill list)
-            const skillConfig = currentConfig.skills[upgradedSkillName]
-            if (
-                !skillConfig ||
-                skillConfig.discount === null ||
-                skillConfig.discount === undefined
-            ) {
-                continue
-            }
-
-            // Invalidate frontend cache (keyed only by skill name, not Uma state)
-            calculatedResultsCache.delete(upgradedSkillName)
-
-            // Mark as pending for recalculation - server will return fresh results
-            if (resultsMap.has(upgradedSkillName)) {
-                addPendingSkillToResults(
-                    upgradedSkillName,
-                    skillConfig.discount,
-                )
-            }
+        if (isSkillOnUma(siblingName) || umaHasUpgradedVersion(siblingName)) {
+            resultsMap.delete(siblingName)
+            selectedSkills.delete(siblingName)
+            continue
         }
+        void returnSkillToResultsTable(siblingName)
     }
 }
-
-// Semantic aliases for the same operation: both add and remove of a basic skill
-// require recalculating upgraded variants. When basic skill is added, upgraded skills
-// show incremental benefit; when removed, they show full standalone benefit.
-// The recalculation logic is identical - mark upgraded skills as pending for re-simulation.
-export const updateUpgradedSkillsForBasicSkill =
-    recalculateUpgradedSkillsForBasicChange
-export const restoreUpgradedSkillsForBasicSkill =
-    recalculateUpgradedSkillsForBasicChange
 
 /**
  * Add a skill back to the results table when removed from Uma.

--- a/public/skillHelpers.ts
+++ b/public/skillHelpers.ts
@@ -1,3 +1,4 @@
+import { applyDiscount } from '../utils'
 import { SKILLS_TO_IGNORE } from './constants'
 import {
     getCurrentConfig,
@@ -345,7 +346,7 @@ export function getSkillCostWithDiscount(skillName: string): number {
 
     const baseCost = getSkillBaseCost(skillName)
     const discount = currentConfig?.skills[skillName]?.discount ?? 0
-    let totalCost = Math.ceil(baseCost * (1 - discount / 100))
+    let totalCost = applyDiscount(baseCost, discount)
 
     if (!skillmeta || !skillnames) return totalCost
 
@@ -394,9 +395,7 @@ export function getSkillCostWithDiscount(skillName: string): number {
             const prereqBaseCost = otherMeta.baseCost ?? 200
             const prereqDiscount =
                 currentConfig?.skills[primaryName]?.discount ?? 0
-            totalCost += Math.ceil(
-                prereqBaseCost * (1 - prereqDiscount / 100),
-            )
+            totalCost += applyDiscount(prereqBaseCost, prereqDiscount)
         }
     }
 

--- a/public/skillHelpers.ts
+++ b/public/skillHelpers.ts
@@ -351,11 +351,24 @@ export function getSkillCostWithDiscount(skillName: string): number {
     const currentOrder = currentMeta.order ?? 0
     const umaSkills = currentConfig?.uma?.skills || []
 
+    // Find the most advanced (lowest order) skill the Uma has in this group
+    let umaGroupOrder = Infinity
+    for (const umaSkill of umaSkills) {
+        const umaSkillId = findSkillId(umaSkill)
+        if (!umaSkillId) continue
+        const umaMeta = skillmeta[umaSkillId]
+        if (umaMeta?.groupId === currentGroupId) {
+            umaGroupOrder = Math.min(umaGroupOrder, umaMeta.order ?? 0)
+        }
+    }
+
     // Find prerequisite skills (same groupId, higher order = basic versions)
     for (const [otherSkillId, otherMeta] of Object.entries(skillmeta)) {
+        const otherOrder = otherMeta.order ?? 0
         if (
             otherMeta.groupId === currentGroupId &&
-            (otherMeta.order ?? 0) > currentOrder
+            otherOrder > currentOrder &&
+            umaGroupOrder > otherOrder
         ) {
             const otherSkillNames = skillnames[otherSkillId]
             if (!otherSkillNames) continue
@@ -369,21 +382,13 @@ export function getSkillCostWithDiscount(skillName: string): number {
                 continue
             }
 
-            // Check if Uma already has this prerequisite
-            const umaHasPrereq = umaSkills.some((umaSkill) => {
-                const umaSkillId = findSkillId(umaSkill)
-                return umaSkillId === otherSkillId
-            })
-
-            if (!umaHasPrereq) {
-                // Add prerequisite cost with its discount
-                const prereqBaseCost = otherMeta.baseCost ?? 200
-                const prereqDiscount =
-                    currentConfig?.skills[primaryName]?.discount ?? 0
-                totalCost += Math.ceil(
-                    prereqBaseCost * (1 - prereqDiscount / 100),
-                )
-            }
+            // Add prerequisite cost with its discount
+            const prereqBaseCost = otherMeta.baseCost ?? 200
+            const prereqDiscount =
+                currentConfig?.skills[primaryName]?.discount ?? 0
+            totalCost += Math.ceil(
+                prereqBaseCost * (1 - prereqDiscount / 100),
+            )
         }
     }
 

--- a/public/skillHelpers.ts
+++ b/public/skillHelpers.ts
@@ -256,9 +256,14 @@ export function getGroupVariantOnUma(skillName: string): string | null {
     return null
 }
 
+// Debuff variants (× suffix) share the group ID but are not part of the upgrade chain.
+function isDebuffVariantName(name: string): boolean {
+    return name.endsWith(' ×')
+}
+
 /**
  * Get the basic variant (higher order) of a skill in the same group.
- * Returns null if no basic variant exists.
+ * Returns null if no basic variant exists. × debuff variants are ignored.
  */
 export function getBasicVariant(skillName: string): string | null {
     const skillmeta = getSkillmeta()
@@ -274,14 +279,13 @@ export function getBasicVariant(skillName: string): string | null {
     const currentGroupId = currentMeta.groupId
     const currentOrder = currentMeta.order ?? 0
 
-    // Find skill with higher order (basic version) in the same group
     for (const [otherId, otherMeta] of Object.entries(skillmeta)) {
         if (
             otherMeta.groupId === currentGroupId &&
             (otherMeta.order ?? 0) > currentOrder
         ) {
             const names = skillnames[otherId]
-            if (names?.[0]) {
+            if (names?.[0] && !isDebuffVariantName(names[0])) {
                 return names[0]
             }
         }
@@ -291,12 +295,15 @@ export function getBasicVariant(skillName: string): string | null {
 
 /**
  * Get the upgraded variant (lower order) of a skill in the same group.
- * Returns null if no upgraded variant exists.
+ * Returns null if no upgraded variant exists. × debuff variants are ignored
+ * both as lookup targets and as the input skill.
  */
 export function getUpgradedVariant(skillName: string): string | null {
     const skillmeta = getSkillmeta()
     const skillnames = getSkillnames()
     if (!skillmeta || !skillnames) return null
+
+    if (isDebuffVariantName(skillName)) return null
 
     const skillId = findSkillId(skillName)
     if (!skillId) return null
@@ -307,14 +314,13 @@ export function getUpgradedVariant(skillName: string): string | null {
     const currentGroupId = currentMeta.groupId
     const currentOrder = currentMeta.order ?? 0
 
-    // Find skill with lower order (upgraded version) in the same group
     for (const [otherId, otherMeta] of Object.entries(skillmeta)) {
         if (
             otherMeta.groupId === currentGroupId &&
             (otherMeta.order ?? 0) < currentOrder
         ) {
             const names = skillnames[otherId]
-            if (names?.[0]) {
+            if (names?.[0] && !isDebuffVariantName(names[0])) {
                 return names[0]
             }
         }

--- a/public/skillHelpers.ts
+++ b/public/skillHelpers.ts
@@ -98,6 +98,32 @@ export function getOtherVariant(skillName: string): string | string[] | null {
 }
 
 /**
+ * Canonical skill-variant names that share discount / default state with `skillName`.
+ * For a ○/◎ pair, returns both variants. Always includes `skillName` itself. Does
+ * not include the stripped base name; callers that need to touch a legacy
+ * base-name config entry must handle it separately.
+ */
+export function getDiscountVariants(skillName: string): string[] {
+    const baseName = getBaseSkillName(skillName)
+    const variants = getVariantsForBaseName(baseName)
+    const names = new Set<string>([skillName])
+
+    if (variants.length === 2) {
+        for (const variant of variants) names.add(variant)
+    } else {
+        const otherVariant = getOtherVariant(skillName)
+        if (otherVariant) {
+            const others = Array.isArray(otherVariant)
+                ? otherVariant
+                : [otherVariant]
+            for (const variant of others) names.add(variant)
+        }
+    }
+
+    return [...names]
+}
+
+/**
  * Updates the default value for a skill and all its variants.
  * Handles both ○/◎ variant pairs consistently.
  */
@@ -109,27 +135,7 @@ export function updateSkillVariantsDefault(
     const currentConfig = getCurrentConfig()
     if (!currentConfig) return
 
-    const baseName = getBaseSkillName(skillName)
-    const variants = getVariantsForBaseName(baseName)
-
-    // Determine which skills to update - always include skillName
-    let skillsToUpdate: string[]
-    if (variants.length === 2) {
-        skillsToUpdate = [...new Set([skillName, ...variants])]
-    } else {
-        const otherVariant = getOtherVariant(skillName)
-        if (otherVariant) {
-            const variantsToAdd = Array.isArray(otherVariant)
-                ? otherVariant
-                : [otherVariant]
-            skillsToUpdate = [skillName, ...variantsToAdd]
-        } else {
-            skillsToUpdate = [skillName]
-        }
-    }
-
-    // Apply the operation to all relevant skills
-    for (const variantName of skillsToUpdate) {
+    for (const variantName of getDiscountVariants(skillName)) {
         if (!currentConfig.skills[variantName]) continue
 
         if (operation === 'remove') {

--- a/public/skillHelpers.ts
+++ b/public/skillHelpers.ts
@@ -194,6 +194,14 @@ export function getSkillOrder(skillName: string): number {
     return skillmeta[skillId]?.order ?? 0
 }
 
+export function compareSkills(a: string, b: string): number {
+    const orderDiff = getSkillOrder(a) - getSkillOrder(b)
+    if (orderDiff !== 0) return orderDiff
+    const idA = findSkillId(a) ?? ''
+    const idB = findSkillId(b) ?? ''
+    return idA.localeCompare(idB)
+}
+
 /**
  * Check if Uma has an upgraded version of the given skill.
  * Upgraded skills have lower order numbers in the same groupId.

--- a/public/skillsUI.ts
+++ b/public/skillsUI.ts
@@ -10,6 +10,7 @@ import {
     deleteSkill,
     getBaseSkillName,
     getCanonicalSkillName,
+    getDiscountVariants,
     getOtherVariant,
     getSkillCostWithDiscount,
     getSkillIconUrl,
@@ -21,6 +22,60 @@ import { getCurrentConfig } from './state'
 
 const squareClasses =
     'py-0.5 px-1 w-6 h-6 rounded text-[13px] cursor-pointer transition-colors'
+
+/**
+ * Set `discount` on `skillName` and every sibling variant that shares its hint
+ * (e.g. the ○/◎ pair). The results table is updated in lockstep for each
+ * variant so a single click produces a row for each skill the discount applies
+ * to, not just the clicked one.
+ */
+export function setDiscountForVariants(
+    skillName: string,
+    discount: number | null,
+): void {
+    const currentConfig = getCurrentConfig()
+    if (!currentConfig) return
+
+    if (!currentConfig.skills[skillName]) {
+        currentConfig.skills[skillName] = { discount: null }
+    }
+
+    const variants = getDiscountVariants(skillName)
+    const previous = new Map<string, number | null | undefined>()
+    for (const variantName of variants) {
+        previous.set(variantName, currentConfig.skills[variantName]?.discount)
+    }
+
+    for (const variantName of variants) {
+        if (currentConfig.skills[variantName]) {
+            currentConfig.skills[variantName].discount = discount
+        }
+    }
+
+    // Legacy base-name config entry: some configs carry a discount under the
+    // stripped name (e.g. "Medium Straightaways") alongside the variants.
+    // Mirror the discount there only if the entry already exists.
+    const baseName = getBaseSkillName(skillName)
+    const baseEntryExists = !!currentConfig.skills[baseName]
+    const baseIsDistinctSkill =
+        baseName !== skillName && !variants.includes(baseName)
+    if (baseEntryExists && baseIsDistinctSkill) {
+        const twoVariantPair = getVariantsForBaseName(baseName).length === 2
+        const inputIsBaseItself =
+            !skillName.endsWith(' ○') && !skillName.endsWith(' ◎')
+        if (twoVariantPair || inputIsBaseItself) {
+            currentConfig.skills[baseName].discount = discount
+        }
+    }
+
+    for (const variantName of variants) {
+        updateResultsForDiscountChange(
+            variantName,
+            previous.get(variantName),
+            discount,
+        )
+    }
+}
 
 export function renderSkills(): void {
     const currentConfig = getCurrentConfig()
@@ -366,44 +421,7 @@ export function setupSkillsContainerDelegation(): void {
                 updateSkillVariantsDefault(skillName, 'set', currentDiscount)
             }
         } else {
-            currentConfig.skills[skillName].discount =
-                discount === null ? null : discount
-
-            const baseName = getBaseSkillName(skillName)
-            const variants = getVariantsForBaseName(baseName)
-            if (variants.length === 2) {
-                if (currentConfig.skills[baseName]) {
-                    currentConfig.skills[baseName].discount = discount
-                }
-                variants.forEach((variantName) => {
-                    if (currentConfig.skills[variantName]) {
-                        currentConfig.skills[variantName].discount = discount
-                    }
-                })
-            } else {
-                const otherVariant = getOtherVariant(skillName)
-                if (otherVariant) {
-                    const variantsToUpdate = Array.isArray(otherVariant)
-                        ? otherVariant
-                        : [otherVariant]
-                    variantsToUpdate.forEach((variantName) => {
-                        if (currentConfig.skills[variantName]) {
-                            currentConfig.skills[variantName].discount =
-                                discount
-                        }
-                    })
-                    if (
-                        currentConfig.skills[baseName] &&
-                        !skillName.endsWith(' ○') &&
-                        !skillName.endsWith(' ◎')
-                    ) {
-                        currentConfig.skills[baseName].discount = discount
-                    }
-                }
-            }
-
-            // Update results table based on discount change
-            updateResultsForDiscountChange(skillName, currentDiscount, discount)
+            setDiscountForVariants(skillName, discount)
         }
 
         renderSkills()

--- a/public/skillsUI.ts
+++ b/public/skillsUI.ts
@@ -6,13 +6,13 @@ import {
     updateResultsForDiscountChange,
 } from './resultsUI'
 import {
+    compareSkills,
     deleteSkill,
     getBaseSkillName,
     getCanonicalSkillName,
     getOtherVariant,
     getSkillCostWithDiscount,
     getSkillIconUrl,
-    getSkillOrder,
     getVariantsForBaseName,
     updateSkillVariantsDefault,
 } from './skillHelpers'
@@ -99,14 +99,7 @@ export function renderSkills(): void {
         }
     })
 
-    // Pre-compute skill order to avoid O(n^2) lookups in sort comparator
-    const skillOrderCache = new Map<string, number>()
-    for (const name of skillsToRender) {
-        skillOrderCache.set(name, getSkillOrder(name))
-    }
-    const sortedSkillNames = Array.from(skillsToRender).sort((a, b) => {
-        return (skillOrderCache.get(a) || 0) - (skillOrderCache.get(b) || 0)
-    })
+    const sortedSkillNames = Array.from(skillsToRender).sort(compareSkills)
 
     // Filter out skills that cannot trigger under current settings
     const triggerableSkills = sortedSkillNames.filter(canSkillTriggerByName)

--- a/public/umaUI.ts
+++ b/public/umaUI.ts
@@ -8,6 +8,7 @@ import {
     updateUpgradedSkillsForBasicSkill,
 } from './resultsUI'
 import {
+    compareSkills,
     getBasicVariant,
     getCanonicalSkillName,
     getGroupVariantOnUma,
@@ -468,7 +469,7 @@ export function renderUma(): void {
     // Sort equipped skills by order (same order as the skills list)
     const sortedIndices = skills
         .map((skill, index) => ({ skill, index }))
-        .sort((a, b) => getSkillOrder(a.skill) - getSkillOrder(b.skill))
+        .sort((a, b) => compareSkills(a.skill, b.skill))
     for (const { skill, index } of sortedIndices) {
         skillsDiv.appendChild(createSkillPill(skill, index))
     }

--- a/public/umaUI.ts
+++ b/public/umaUI.ts
@@ -1,28 +1,14 @@
 import { autoSave } from './configManager'
 import { callRenderSkills, registerRenderUma } from './renderCallbacks'
-import {
-    refreshResultsCosts,
-    renderResultsTable,
-    restoreUpgradedSkillsForBasicSkill,
-    returnSkillToResultsTable,
-    updateUpgradedSkillsForBasicSkill,
-} from './resultsUI'
+import { refreshGroupResults, refreshResultsCosts } from './resultsUI'
 import {
     compareSkills,
-    getBasicVariant,
     getCanonicalSkillName,
     getGroupVariantOnUma,
     getSkillCostWithDiscount,
     getSkillIconUrl,
-    getSkillOrder,
-    getUpgradedVariant,
 } from './skillHelpers'
-import {
-    getCalculatedResultsCache,
-    getCurrentConfig,
-    getResultsMap,
-    getSelectedSkills,
-} from './state'
+import { getCalculatedResultsCache, getCurrentConfig } from './state'
 import type { Uma } from './types'
 
 function calculateDropdownWidth(options: string[]): number {
@@ -225,16 +211,17 @@ export function renderUma(): void {
     skillsDiv.appendChild(skillsLabel)
 
     const skills = uma.skills || []
-    const resultsMap = getResultsMap()
-    const selectedSkills = getSelectedSkills()
 
-    function updateSkills(newSkills: string[]) {
+    function updateSkills(newSkills: string[], affectedSkills: string[]) {
         const currentConfig = getCurrentConfig()
         if (!currentConfig) return
         if (!currentConfig.uma) {
             currentConfig.uma = {}
         }
         currentConfig.uma.skills = newSkills
+        for (const affected of affectedSkills) {
+            refreshGroupResults(affected)
+        }
         renderUma()
         callRenderSkills()
         refreshResultsCosts()
@@ -274,31 +261,19 @@ export function renderUma(): void {
                         currentConfig.uma.skillPoints += oldCost
                     }
 
-                    // Return old skill to results table
-                    void returnSkillToResultsTable(skill)
-
-                    // Handle old skill's variant restoration
-                    const oldUpgradedVariant = getUpgradedVariant(skill)
-                    if (!oldUpgradedVariant) {
-                        restoreUpgradedSkillsForBasicSkill(skill)
-                    }
-                    const oldBasicVariant = getBasicVariant(skill)
-                    if (oldBasicVariant) {
-                        void returnSkillToResultsTable(oldBasicVariant)
-                    }
-
                     // Check if new skill already on Uma
                     if (skills.includes(newValue)) {
                         // Just remove the old skill
                         const newSkills = skills.filter((_, i) => i !== index)
-                        updateSkills(newSkills)
+                        updateSkills(newSkills, [skill])
                         return
                     }
 
                     // Check if new skill's variant is already on Uma
                     const existingVariant = getGroupVariantOnUma(newValue)
+                    let newSkills: string[]
                     if (existingVariant && existingVariant !== skill) {
-                        // Another variant already exists, need to handle that
+                        // Another variant already exists, refund its cost and swap.
                         const existingCost =
                             getSkillCostWithDiscount(existingVariant)
                         if (
@@ -307,69 +282,25 @@ export function renderUma(): void {
                         ) {
                             currentConfig.uma.skillPoints += existingCost
                         }
-                        const existingVariantOrder =
-                            getSkillOrder(existingVariant)
-                        const newSkillOrder = getSkillOrder(newValue)
-                        if (existingVariantOrder < newSkillOrder) {
-                            void returnSkillToResultsTable(existingVariant)
-                            restoreUpgradedSkillsForBasicSkill(newValue)
-                        }
-                        // Remove existing variant from skills array
-                        const newSkills = skills.filter(
+                        newSkills = skills.filter(
                             (s, i) => i !== index && s !== existingVariant,
                         )
                         newSkills.push(newValue)
-
-                        // Deduct new skill cost
-                        const newCost = getSkillCostWithDiscount(newValue)
-                        if (
-                            currentConfig?.uma?.skillPoints !== undefined &&
-                            currentConfig?.uma?.skillPoints !== null
-                        ) {
-                            currentConfig.uma.skillPoints -= newCost
-                        }
-
-                        // Handle new skill's variant updates
-                        const newBasicVariant = getBasicVariant(newValue)
-                        if (!newBasicVariant) {
-                            updateUpgradedSkillsForBasicSkill(newValue)
-                        }
-                        resultsMap.delete(newValue)
-                        selectedSkills.delete(newValue)
-                        if (newBasicVariant) {
-                            resultsMap.delete(newBasicVariant)
-                            selectedSkills.delete(newBasicVariant)
-                        }
-
-                        updateSkills(newSkills)
                     } else {
-                        // No conflicting variant, just replace
-                        const newSkills = [...skills]
+                        newSkills = [...skills]
                         newSkills[index] = newValue
-
-                        // Deduct new skill cost
-                        const newCost = getSkillCostWithDiscount(newValue)
-                        if (
-                            currentConfig?.uma?.skillPoints !== undefined &&
-                            currentConfig?.uma?.skillPoints !== null
-                        ) {
-                            currentConfig.uma.skillPoints -= newCost
-                        }
-
-                        // Handle new skill's variant updates
-                        const newBasicVariant = getBasicVariant(newValue)
-                        if (!newBasicVariant) {
-                            updateUpgradedSkillsForBasicSkill(newValue)
-                        }
-                        resultsMap.delete(newValue)
-                        selectedSkills.delete(newValue)
-                        if (newBasicVariant) {
-                            resultsMap.delete(newBasicVariant)
-                            selectedSkills.delete(newBasicVariant)
-                        }
-
-                        updateSkills(newSkills)
                     }
+
+                    // Deduct new skill cost
+                    const newCost = getSkillCostWithDiscount(newValue)
+                    if (
+                        currentConfig?.uma?.skillPoints !== undefined &&
+                        currentConfig?.uma?.skillPoints !== null
+                    ) {
+                        currentConfig.uma.skillPoints -= newCost
+                    }
+
+                    updateSkills(newSkills, [skill, newValue])
                 } else if (!newValue) {
                     // Empty value removes the skill - refund cost
                     if (
@@ -379,23 +310,8 @@ export function renderUma(): void {
                         const skillCost = getSkillCostWithDiscount(skill)
                         currentConfig.uma.skillPoints += skillCost
                     }
-                    // Return skill to results table
-                    void returnSkillToResultsTable(skill)
-
-                    // Check if this was a basic skill - restore upgraded skill full stats
-                    const upgradedVariant = getUpgradedVariant(skill)
-                    if (upgradedVariant) {
-                        restoreUpgradedSkillsForBasicSkill(skill)
-                    }
-
-                    // If this was an upgraded skill, also show basic skill in results
-                    const basicVariant = getBasicVariant(skill)
-                    if (basicVariant) {
-                        void returnSkillToResultsTable(basicVariant)
-                    }
-
                     const newSkills = skills.filter((_, i) => i !== index)
-                    updateSkills(newSkills)
+                    updateSkills(newSkills, [skill])
                 } else {
                     renderUma()
                 }
@@ -433,24 +349,8 @@ export function renderUma(): void {
                 const skillCost = getSkillCostWithDiscount(skill)
                 currentConfig.uma.skillPoints += skillCost
             }
-            // Return skill to results table
-            void returnSkillToResultsTable(skill)
-
-            // Check if this was a basic skill - restore upgraded skill full stats
-            const upgradedVariant = getUpgradedVariant(skill)
-            if (upgradedVariant) {
-                // This is a basic skill (has an upgraded variant), restore upgraded skills
-                restoreUpgradedSkillsForBasicSkill(skill)
-            }
-
-            // If this was an upgraded skill, also show basic skill in results
-            const basicVariant = getBasicVariant(skill)
-            if (basicVariant) {
-                void returnSkillToResultsTable(basicVariant)
-            }
-
             const newSkills = skills.filter((_, i) => i !== index)
-            updateSkills(newSkills)
+            updateSkills(newSkills, [skill])
         })
 
         const iconUrl = getSkillIconUrl(skill)
@@ -501,13 +401,10 @@ export function renderUma(): void {
 
                 // Check if a variant from the same group is on Uma
                 const existingVariant = getGroupVariantOnUma(newSkill)
-                const existingVariantOrder = existingVariant
-                    ? getSkillOrder(existingVariant)
-                    : 0
-                const newSkillOrder = getSkillOrder(newSkill)
 
+                let newSkills: string[]
                 if (existingVariant) {
-                    // Refund the existing variant's cost
+                    // Refund the existing variant's cost and swap it for newSkill.
                     const existingCost =
                         getSkillCostWithDiscount(existingVariant)
                     if (
@@ -516,69 +413,23 @@ export function renderUma(): void {
                     ) {
                         currentConfig.uma.skillPoints += existingCost
                     }
-
-                    // Handle stats restoration based on which variant is replaced
-                    if (existingVariantOrder < newSkillOrder) {
-                        // Existing is upgraded, new is basic - return upgraded to table
-                        void returnSkillToResultsTable(existingVariant)
-                        restoreUpgradedSkillsForBasicSkill(newSkill)
-                    }
-
-                    // Replace variant in skills array
                     const idx = skills.indexOf(existingVariant)
-                    const newSkills = [...skills]
+                    newSkills = [...skills]
                     newSkills[idx] = newSkill
-
-                    // Deduct new skill cost
-                    const newSkillCost = getSkillCostWithDiscount(newSkill)
-                    if (
-                        currentConfig?.uma?.skillPoints !== undefined &&
-                        currentConfig?.uma?.skillPoints !== null
-                    ) {
-                        currentConfig.uma.skillPoints -= newSkillCost
-                    }
-
-                    // Handle stats update for adding basic skill
-                    const basicVariant = getBasicVariant(newSkill)
-                    if (!basicVariant) {
-                        updateUpgradedSkillsForBasicSkill(newSkill)
-                    }
-
-                    // Hide variants from results
-                    resultsMap.delete(newSkill)
-                    selectedSkills.delete(newSkill)
-                    if (basicVariant) {
-                        resultsMap.delete(basicVariant)
-                        selectedSkills.delete(basicVariant)
-                    }
-
-                    updateSkills(newSkills)
                 } else {
-                    // No variant on Uma, just add the skill
-                    const newSkillCost = getSkillCostWithDiscount(newSkill)
-                    if (
-                        currentConfig?.uma?.skillPoints !== undefined &&
-                        currentConfig?.uma?.skillPoints !== null
-                    ) {
-                        currentConfig.uma.skillPoints -= newSkillCost
-                    }
-
-                    // Handle stats update for adding basic skill
-                    const basicVariant = getBasicVariant(newSkill)
-                    if (!basicVariant) {
-                        updateUpgradedSkillsForBasicSkill(newSkill)
-                    }
-
-                    // Hide variants from results
-                    resultsMap.delete(newSkill)
-                    selectedSkills.delete(newSkill)
-                    if (basicVariant) {
-                        resultsMap.delete(basicVariant)
-                        selectedSkills.delete(basicVariant)
-                    }
-
-                    updateSkills([...skills, newSkill])
+                    newSkills = [...skills, newSkill]
                 }
+
+                // Deduct new skill cost
+                const newSkillCost = getSkillCostWithDiscount(newSkill)
+                if (
+                    currentConfig?.uma?.skillPoints !== undefined &&
+                    currentConfig?.uma?.skillPoints !== null
+                ) {
+                    currentConfig.uma.skillPoints -= newSkillCost
+                }
+
+                updateSkills(newSkills, [newSkill])
             } else {
                 renderUma()
             }

--- a/skill-helpers.test.ts
+++ b/skill-helpers.test.ts
@@ -1,0 +1,65 @@
+import { beforeAll, describe, expect, it } from 'vitest'
+import {
+    buildSkillNameLookup,
+    findSkillId,
+    getBasicVariant,
+    getUpgradedVariant,
+} from './public/skillHelpers'
+import {
+    setSkillmeta,
+    setSkillNameToId,
+    setSkillnames,
+} from './public/state'
+
+describe('variant lookups exclude × debuff variants', () => {
+    beforeAll(() => {
+        // Winter Runner group: ◎ (upgrade) -> ○ (base) -> × (debuff, same group, higher order).
+        // The × variant is not part of the upgrade chain; it shouldn't be treated as
+        // a more basic form of ○.
+        setSkillmeta({
+            '200201': { baseCost: 110, groupId: '20020', order: 1600 },
+            '200202': { baseCost: 90, groupId: '20020', order: 1610 },
+            '200203': { baseCost: 50, groupId: '20020', order: 1620 },
+        })
+        setSkillnames({
+            '200201': ['Winter Runner ◎'],
+            '200202': ['Winter Runner ○'],
+            '200203': ['Winter Runner ×'],
+        })
+        setSkillNameToId({
+            'Winter Runner ◎': '200201',
+            'Winter Runner ○': '200202',
+            'Winter Runner ×': '200203',
+        })
+        buildSkillNameLookup()
+    })
+
+    it('findSkillId resolves all three variants', () => {
+        expect(findSkillId('Winter Runner ◎')).toBe('200201')
+        expect(findSkillId('Winter Runner ○')).toBe('200202')
+        expect(findSkillId('Winter Runner ×')).toBe('200203')
+    })
+
+    it('getBasicVariant(○) is null — the × debuff is not a prerequisite', () => {
+        // Regression test for #44: when adding ○ to Uma, the caller uses
+        // !getBasicVariant(○) to decide whether to invalidate the upgraded
+        // variant's cache. Returning × here leaves the cache stale.
+        expect(getBasicVariant('Winter Runner ○')).toBeNull()
+    })
+
+    it('getBasicVariant(◎) returns ○', () => {
+        expect(getBasicVariant('Winter Runner ◎')).toBe('Winter Runner ○')
+    })
+
+    it('getUpgradedVariant(○) returns ◎', () => {
+        expect(getUpgradedVariant('Winter Runner ○')).toBe('Winter Runner ◎')
+    })
+
+    it('getUpgradedVariant(◎) is null', () => {
+        expect(getUpgradedVariant('Winter Runner ◎')).toBeNull()
+    })
+
+    it('getUpgradedVariant(×) is null — × is not upgraded to anything', () => {
+        expect(getUpgradedVariant('Winter Runner ×')).toBeNull()
+    })
+})

--- a/upgrade-cascade.test.ts
+++ b/upgrade-cascade.test.ts
@@ -1,0 +1,204 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { buildSkillNameLookup } from './public/skillHelpers'
+import { refreshGroupResults } from './public/resultsUI'
+import {
+    getCalculatedResultsCache,
+    getResultsMap,
+    setCurrentConfig,
+    setSkillmeta,
+    setSkillNameToId,
+    setSkillnames,
+} from './public/state'
+import type { SkillResult, SkillResultWithStatus } from './public/types'
+
+// renderResultsTable reads document.getElementById and no-ops if the tbody is
+// missing. Stubbing here lets us exercise the result-map side-effects without
+// pulling in jsdom for a single test file.
+vi.stubGlobal('document', {
+    getElementById: () => null,
+})
+
+const freshResult = (skill: string, mean: number): SkillResult => ({
+    skill,
+    cost: 100,
+    discount: 0,
+    meanLength: mean,
+    medianLength: mean,
+    meanLengthPerCost: mean / 100,
+    minLength: 0,
+    maxLength: mean * 2,
+    ciLower: 0,
+    ciUpper: mean * 2,
+})
+
+const freshWithStatus = (
+    skill: string,
+    mean: number,
+): SkillResultWithStatus => ({
+    ...freshResult(skill, mean),
+    status: 'fresh',
+})
+
+// Medium Straightaways group mirrors the Flash Forward ↑ ◎ ↑ ○ chain
+// from the live data (lower order = more upgraded).
+const FLASH_FORWARD = 'Flash Forward'
+const MEDIUM_RARE = 'Medium Straightaways ◎'
+const MEDIUM_NORMAL = 'Medium Straightaways ○'
+
+function seedGroup(umaSkills: string[]): void {
+    setCurrentConfig({
+        skills: {
+            [FLASH_FORWARD]: { discount: 10 },
+            [MEDIUM_RARE]: { discount: 10 },
+            [MEDIUM_NORMAL]: { discount: 10 },
+        },
+        uma: { skills: umaSkills },
+    })
+    const cache = getCalculatedResultsCache()
+    cache.clear()
+    cache.set(FLASH_FORWARD, freshResult(FLASH_FORWARD, 0.5))
+    cache.set(MEDIUM_RARE, freshResult(MEDIUM_RARE, 0.3))
+    cache.set(MEDIUM_NORMAL, freshResult(MEDIUM_NORMAL, 0.2))
+
+    const results = getResultsMap()
+    results.clear()
+    // Seed results for every sibling not on Uma.
+    for (const skill of [FLASH_FORWARD, MEDIUM_RARE, MEDIUM_NORMAL]) {
+        if (!umaSkills.includes(skill)) {
+            results.set(
+                skill,
+                freshWithStatus(
+                    skill,
+                    skill === FLASH_FORWARD
+                        ? 0.5
+                        : skill === MEDIUM_RARE
+                          ? 0.3
+                          : 0.2,
+                ),
+            )
+        }
+    }
+}
+
+describe('refreshGroupResults', () => {
+    beforeAll(() => {
+        setSkillmeta({
+            '201103': { baseCost: 150, groupId: '20110', order: 20290 },
+            '201101': { baseCost: 110, groupId: '20110', order: 20300 },
+            '201102': { baseCost: 100, groupId: '20110', order: 20310 },
+        })
+        setSkillnames({
+            '201103': [FLASH_FORWARD],
+            '201101': [MEDIUM_RARE],
+            '201102': [MEDIUM_NORMAL],
+        })
+        setSkillNameToId({
+            [FLASH_FORWARD]: '201103',
+            [MEDIUM_RARE]: '201101',
+            [MEDIUM_NORMAL]: '201102',
+        })
+        buildSkillNameLookup()
+    })
+
+    beforeEach(() => {
+        seedGroup([])
+    })
+
+    it('adding ○ invalidates every sibling cache and keeps ◎/Flash Forward pending', () => {
+        // Caller updated uma.skills to [○] before invoking refreshGroupResults.
+        seedGroup([MEDIUM_NORMAL])
+
+        refreshGroupResults(MEDIUM_NORMAL)
+
+        const cache = getCalculatedResultsCache()
+        // Every sibling's cache is dropped — a change in uma.skills can affect any
+        // sibling's simulation baseline, not just the more-upgraded ones.
+        expect(cache.has(FLASH_FORWARD)).toBe(false)
+        expect(cache.has(MEDIUM_RARE)).toBe(false)
+        expect(cache.has(MEDIUM_NORMAL)).toBe(false)
+
+        const results = getResultsMap()
+        expect(results.get(FLASH_FORWARD)?.status).toBe('pending')
+        expect(results.get(MEDIUM_RARE)?.status).toBe('pending')
+        // ○ is on Uma; filter would hide it, so it's dropped from resultsMap.
+        expect(results.has(MEDIUM_NORMAL)).toBe(false)
+    })
+
+    it('adding ◎ invalidates Flash Forward and drops dominated ○', () => {
+        // Regression test for the original Flash Forward bug: adding ◎ must not
+        // leave Flash Forward's cached mean in place, since its simulation
+        // baseline changed.
+        seedGroup([MEDIUM_RARE])
+
+        refreshGroupResults(MEDIUM_RARE)
+
+        const cache = getCalculatedResultsCache()
+        expect(cache.has(FLASH_FORWARD)).toBe(false)
+        expect(cache.has(MEDIUM_RARE)).toBe(false)
+        expect(cache.has(MEDIUM_NORMAL)).toBe(false)
+
+        const results = getResultsMap()
+        expect(results.get(FLASH_FORWARD)?.status).toBe('pending')
+        // ◎ is on Uma, ○ is dominated by ◎: both filtered out of results.
+        expect(results.has(MEDIUM_RARE)).toBe(false)
+        expect(results.has(MEDIUM_NORMAL)).toBe(false)
+    })
+
+    it('overwriting Flash Forward with ○ restores BOTH ◎ and Flash Forward to results', () => {
+        // Regression test for the reported bug: Uma had Flash Forward, then the
+        // user swaps to ○. Flash Forward was hiding both ◎ and ○ from results.
+        // After the swap, only ○ is on Uma — Flash Forward and ◎ should both
+        // reappear in the results map.
+
+        // Initial state: Uma had Flash Forward, ◎ and ○ were hidden.
+        seedGroup([FLASH_FORWARD])
+        // Simulate the hidden state of ◎ and ○ (filter would have removed them).
+        const results = getResultsMap()
+        results.delete(MEDIUM_RARE)
+        results.delete(MEDIUM_NORMAL)
+
+        // User swaps: uma.skills is now [○] and refreshGroupResults is called.
+        setCurrentConfig({
+            skills: {
+                [FLASH_FORWARD]: { discount: 10 },
+                [MEDIUM_RARE]: { discount: 10 },
+                [MEDIUM_NORMAL]: { discount: 10 },
+            },
+            uma: { skills: [MEDIUM_NORMAL] },
+        })
+        refreshGroupResults(MEDIUM_NORMAL)
+
+        expect(results.has(FLASH_FORWARD)).toBe(true)
+        expect(results.has(MEDIUM_RARE)).toBe(true)
+        expect(results.has(MEDIUM_NORMAL)).toBe(false)
+    })
+
+    it('removing the Uma skill restores all siblings to results', () => {
+        seedGroup([FLASH_FORWARD])
+        const results = getResultsMap()
+        // Previously hidden because of Flash Forward on Uma.
+        results.delete(MEDIUM_RARE)
+        results.delete(MEDIUM_NORMAL)
+
+        setCurrentConfig({
+            skills: {
+                [FLASH_FORWARD]: { discount: 10 },
+                [MEDIUM_RARE]: { discount: 10 },
+                [MEDIUM_NORMAL]: { discount: 10 },
+            },
+            uma: { skills: [] },
+        })
+        refreshGroupResults(FLASH_FORWARD)
+
+        expect(results.has(FLASH_FORWARD)).toBe(true)
+        expect(results.has(MEDIUM_RARE)).toBe(true)
+        expect(results.has(MEDIUM_NORMAL)).toBe(true)
+    })
+
+    it('no-ops for a skill outside any group', () => {
+        // Use a skill id not registered in skillmeta; nothing should change.
+        refreshGroupResults('Unknown Skill')
+        const cache = getCalculatedResultsCache()
+        expect(cache.size).toBe(3)
+    })
+})

--- a/utils.test.ts
+++ b/utils.test.ts
@@ -974,6 +974,56 @@ describe('calculateSkillCost', () => {
         )
         expect(result).toBe(110)
     })
+
+    it('skips all prerequisites covered by an equipped higher-tier skill', () => {
+        // Flash Forward (order 20290) with Medium Straightaways ◎ (order 20300) equipped
+        // ◎ covers ○ (order 20310), so neither prerequisite should be charged
+        // Expected cost: 150 (just Flash Forward itself)
+        const skillMeta: Record<
+            string,
+            { baseCost: number; groupId?: string; order?: number }
+        > = {
+            '201101': {
+                baseCost: 110,
+                groupId: '20110',
+                order: 20300,
+            },
+            '201102': {
+                baseCost: 100,
+                groupId: '20110',
+                order: 20310,
+            },
+            '201103': {
+                baseCost: 150,
+                groupId: '20110',
+                order: 20290,
+            },
+        }
+        const skillNames: Record<string, string[]> = {
+            '201101': ['Medium Straightaways ◎'],
+            '201102': ['Medium Straightaways ○'],
+            '201103': ['Flash Forward'],
+        }
+        const skillIdToName: Record<string, string> = {
+            '201101': 'Medium Straightaways ◎',
+            '201102': 'Medium Straightaways ○',
+            '201103': 'Flash Forward',
+        }
+        const context = {
+            skillMeta,
+            skillNames,
+            skillIdToName,
+            skillNameToConfigKey: {} as Record<string, string>,
+            configSkills: {} as Record<string, { discount?: number | null }>,
+            baseUmaSkillIds: ['201101'], // Uma has ◎ equipped
+        }
+        const result = calculateSkillCost(
+            '201103',
+            { discount: 0 },
+            context,
+        )
+        expect(result).toBe(150)
+    })
 })
 
 describe('formatTable', () => {

--- a/utils.test.ts
+++ b/utils.test.ts
@@ -6,6 +6,7 @@ import {
     type ThresholdStat,
 } from './uma-tools/uma-skill-tools/CourseData'
 import {
+    applyDiscount,
     buildSkillNameLookup,
     type CurrentSettings,
     calculateSkillCost,
@@ -839,23 +840,42 @@ describe('calculateSkillCost', () => {
         expect(result).toBe(170)
     })
 
-    it('rounds to nearest integer after discount', () => {
-        // 150 * 0.93 = 139.5 → round to 140 (not ceil to 140)
-        // 150 * 0.97 = 145.5 → round to 146
+    it('floors fractional cost after discount to match in-game display', () => {
+        // In-game observation: Late Surger Savvy ○ (110) at 35% = 71, not 72.
+        // 150 * 0.93 = 139.5 → 139, 150 * 0.97 = 145.5 → 145.
         const skillMeta2 = { skill: { baseCost: 150 } }
         const result1 = calculateSkillCost(
             'skill',
             { discount: 7 },
             { skillMeta: skillMeta2 },
         )
-        expect(result1).toBe(140) // round(139.5) = 140
+        expect(result1).toBe(139)
 
         const result2 = calculateSkillCost(
             'skill',
             { discount: 3 },
             { skillMeta: skillMeta2 },
         )
-        expect(result2).toBe(146) // round(145.5) = 146
+        expect(result2).toBe(145)
+    })
+
+    it('matches in-game cost for Late Surger Savvy at 35% discount', () => {
+        const skillMeta: Record<
+            string,
+            { baseCost: number; groupId?: string; order?: number }
+        > = {
+            '201541': { baseCost: 130, groupId: '20154', order: 21180 },
+            '201542': { baseCost: 110, groupId: '20154', order: 21190 },
+        }
+        const normal = calculateSkillCost(
+            '201542',
+            { discount: 35 },
+            { skillMeta },
+        )
+        expect(normal).toBe(71) // floor(110 * 0.65) = floor(71.5)
+
+        const rareOwnCost = applyDiscount(130, 35)
+        expect(rareOwnCost).toBe(84) // floor(130 * 0.65) = floor(84.5)
     })
 
     it('uses default cost of 200 for unknown skill', () => {

--- a/utils.ts
+++ b/utils.ts
@@ -490,13 +490,28 @@ export function calculateSkillCost(
         const currentGroupId = currentSkill.groupId
         const currentOrder = currentSkill.order ?? 0
 
+        // Find the most advanced (lowest order) skill the Uma has in this group
+        let umaGroupOrder = Infinity
+        if (baseUmaSkillIds) {
+            for (const umaId of baseUmaSkillIds) {
+                const umaMeta = skillMeta[umaId]
+                if (umaMeta?.groupId === currentGroupId) {
+                    umaGroupOrder = Math.min(
+                        umaGroupOrder,
+                        umaMeta.order ?? 0,
+                    )
+                }
+            }
+        }
+
         for (const [otherSkillId, otherSkillMeta] of Object.entries(
             skillMeta,
         )) {
+            const otherOrder = otherSkillMeta.order ?? 0
             if (
                 otherSkillMeta.groupId === currentGroupId &&
-                (otherSkillMeta.order ?? 0) > currentOrder &&
-                !baseUmaSkillIds.includes(otherSkillId)
+                otherOrder > currentOrder &&
+                umaGroupOrder > otherOrder
             ) {
                 const otherSkillNames = skillNames[otherSkillId]
                 if (otherSkillNames) {

--- a/utils.ts
+++ b/utils.ts
@@ -456,6 +456,11 @@ export interface SkillCostContext {
     skillNameToConfigKey?: Record<string, string>
 }
 
+// Uses Math.floor to match in-game cost display (e.g. 110 * 0.65 = 71.5 → 71).
+export function applyDiscount(baseCost: number, discount: number): number {
+    return Math.floor(baseCost * (1 - discount / 100))
+}
+
 export function calculateSkillCost(
     skillId: string,
     skillConfig: { discount?: number | null },
@@ -472,7 +477,7 @@ export function calculateSkillCost(
     const currentSkill = skillMeta[skillId]
     const baseCost = currentSkill?.baseCost ?? 200
     const discount = skillConfig.discount ?? 0
-    let totalCost = Math.round(baseCost * (1 - discount / 100))
+    let totalCost = applyDiscount(baseCost, discount)
 
     const skillsToIgnore = [
         '99 Problems',
@@ -535,9 +540,7 @@ export function calculateSkillCost(
                 }
 
                 const otherBaseCost = otherSkillMeta.baseCost ?? 200
-                totalCost += Math.round(
-                    otherBaseCost * (1 - otherDiscount / 100),
-                )
+                totalCost += applyDiscount(otherBaseCost, otherDiscount)
             }
         }
     }


### PR DESCRIPTION
## Summary

Three related fixes bundled on this branch:

1. **Prerequisite cost for 3-level upgrades (#53)** — when an intermediate skill (e.g. ◎) is equipped, all its prerequisites are now recognized as covered. Finds the most advanced skill the Uma has in the group and skips all prerequisites at that level or below. Fixed in both `utils.ts` and `public/skillHelpers.ts`.
2. **Skill cost rounding (partial #40)** — unified the discount math behind `applyDiscount(baseCost, discount)` in `utils.ts`, which uses `Math.floor` to match in-game display. Previously frontend used `Math.ceil` and backend used `Math.round`, both off-by-one (e.g. Late Surger Savvy ○ at 35% showed 72 in-game shows 71).
3. **Inherited unique ordering** — added skill-ID tiebreak when `order` values are equal, so inherited uniques (all order=30) now display in in-game order instead of insertion order.
4. **Stale results for upgraded skill after adding basic skill (#44)** — `getBasicVariant` and `getUpgradedVariant` were treating the × debuff variant as part of the upgrade chain (because it shares the group ID and has a higher order). This caused the cache-invalidation branch to be skipped when a basic ○ skill was added to Uma, leaving stale full-effect mean/median values on the ◎ result until the user clicked "Run Calculations". × variants are now explicitly excluded from both lookups.

Issue: #40
Issue: #44
Issue: #53

## Test plan

- [x] All 264 tests pass, including new `skill-helpers.test.ts` regression cases for #44 and the Late Surger Savvy cost cases for #40
- [x] Type check passes
- [ ] Verify in browser:
  - Flash Forward shows cost 150 (not 360) when Medium Straightaways ◎ is equipped
  - Adding Winter Runner ○ to Uma immediately updates Winter Runner ◎ mean/median to the incremental value (no need to click Run Calculations)
  - Inherited uniques show in in-game order in the equipped skills row
  - Late Surger Savvy ○ at 35% discount shows cost 71 (not 72)