### PR TITLE
Base discount-dropdown switch on skills pane width; scroll whole results view

### DIFF
--- a/public/app.ts
+++ b/public/app.ts
@@ -29,7 +29,6 @@ import {
 } from './devConfigSync'
 import { autoSave, loadConfig, loadConfigFiles } from './configManager'
 import { setupPaneResizer } from './paneResizer'
-import { MOBILE_MEDIA_QUERY } from './responsive'
 import {
     renderResultsTable,
     setupResultsTableSorting,
@@ -44,6 +43,7 @@ import {
     renderSkills,
     setupSkillFilters,
     setupSkillsContainerDelegation,
+    setupDiscountWidthObserver,
 } from './skillsUI'
 import {
     getCalculatedResultsCache,
@@ -236,11 +236,10 @@ setupSkillFilters()
 // Make the skills/results split draggable (width on desktop, height on mobile).
 setupPaneResizer()
 
-// The discount control swaps between a button row (desktop) and a dropdown
-// (mobile), so re-render the skills list whenever the breakpoint is crossed.
-window
-    .matchMedia(MOBILE_MEDIA_QUERY)
-    .addEventListener('change', () => renderSkills())
+// The discount control swaps between a button row (wide pane) and a dropdown
+// (narrow pane), so re-render the skills list whenever the skills pane crosses
+// the width threshold (window resize, pane divider drag, etc.).
+setupDiscountWidthObserver()
 
 // Set up results table sorting and select-all checkbox
 setupResultsTableSorting()

--- a/public/index.html
+++ b/public/index.html
@@ -172,7 +172,7 @@
 
                 <div
                     id="results-container"
-                    class="flex-1 bg-zinc-800 text-zinc-200 p-2.5 rounded-md text-sm leading-normal overflow-y-auto overflow-x-auto border border-zinc-700 mb-2.5"
+                    class="bg-zinc-800 text-zinc-200 p-2.5 rounded-md text-sm leading-normal overflow-x-auto border border-zinc-700 mb-2.5"
                 >
                     <div
                         id="results-status"

--- a/public/responsive.test.ts
+++ b/public/responsive.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import {
+    DISCOUNT_DROPDOWN_MAX_PANEL_WIDTH,
+    shouldUseDiscountDropdownForWidth,
+} from './responsive'
+
+describe('shouldUseDiscountDropdownForWidth', () => {
+    it('uses the dropdown when the pane is narrower than the threshold', () => {
+        expect(
+            shouldUseDiscountDropdownForWidth(
+                DISCOUNT_DROPDOWN_MAX_PANEL_WIDTH - 1,
+            ),
+        ).toBe(true)
+        expect(shouldUseDiscountDropdownForWidth(240)).toBe(true)
+    })
+
+    it('uses the button row once the pane is at least the threshold wide', () => {
+        expect(
+            shouldUseDiscountDropdownForWidth(
+                DISCOUNT_DROPDOWN_MAX_PANEL_WIDTH,
+            ),
+        ).toBe(false)
+        expect(shouldUseDiscountDropdownForWidth(800)).toBe(false)
+    })
+})

--- a/public/responsive.ts
+++ b/public/responsive.ts
@@ -6,3 +6,14 @@ export const MOBILE_MEDIA_QUERY = '(max-width: 767.98px)'
 export function isMobileViewport(): boolean {
     return window.matchMedia(MOBILE_MEDIA_QUERY).matches
 }
+
+// Below this skills-pane width the seven-button discount row no longer fits
+// comfortably next to the skill name, so the per-skill discount control
+// collapses to a compact dropdown. This is measured against the pane that holds
+// the discounts rather than the full window width, so a narrowed (resized)
+// desktop pane collapses too — not just narrow phones.
+export const DISCOUNT_DROPDOWN_MAX_PANEL_WIDTH = 480
+
+export function shouldUseDiscountDropdownForWidth(panelWidth: number): boolean {
+    return panelWidth < DISCOUNT_DROPDOWN_MAX_PANEL_WIDTH
+}

--- a/public/skillsUI.ts
+++ b/public/skillsUI.ts
@@ -24,7 +24,10 @@ import {
 import { attachSkillAutocomplete } from './skillAutocomplete'
 import { describeSkill } from './skillDescription'
 import { canSkillTriggerByName } from './skillTrigger'
-import { isMobileViewport } from './responsive'
+import {
+    isMobileViewport,
+    shouldUseDiscountDropdownForWidth,
+} from './responsive'
 import { getCurrentConfig, getResultsMap, getSelectedSkills } from './state'
 import { showToast } from './toast'
 
@@ -158,9 +161,42 @@ export function setDiscountForVariants(
 const DISCOUNT_OPTIONS: (number | null)[] = [null, 0, 10, 20, 30, 35, 40]
 
 /**
- * Compact discount picker for mobile, where the seven-button row is too wide.
- * `null` ("None") removes the skill from the results table; a number sets that
- * discount. Mirrors the non-active branch of the button delegation handler.
+ * Decide whether per-skill discounts render as a dropdown (narrow pane) or the
+ * full button row (wide pane). Measured against the skills container's own
+ * width, not the window, so resizing the pane divider collapses the row even on
+ * desktop. Falls back to the window breakpoint before the pane has a measurable
+ * width (very first render).
+ */
+function shouldUseDiscountDropdown(): boolean {
+    const container = document.getElementById('skills-container')
+    if (!container || container.clientWidth === 0) return isMobileViewport()
+    return shouldUseDiscountDropdownForWidth(container.clientWidth)
+}
+
+/**
+ * Re-render the skills list when the skills pane crosses the discount-dropdown
+ * width threshold (e.g. the user drags the pane divider). Tracks the last mode
+ * so we only re-render on an actual flip rather than on every resize frame.
+ */
+export function setupDiscountWidthObserver(): void {
+    const container = document.getElementById('skills-container')
+    if (!container || typeof ResizeObserver === 'undefined') return
+    let lastDropdown = shouldUseDiscountDropdown()
+    const observer = new ResizeObserver(() => {
+        const dropdown = shouldUseDiscountDropdown()
+        if (dropdown !== lastDropdown) {
+            lastDropdown = dropdown
+            renderSkills()
+        }
+    })
+    observer.observe(container)
+}
+
+/**
+ * Compact discount picker for a narrow skills pane, where the seven-button row
+ * is too wide. `null` ("None") removes the skill from the results table; a
+ * number sets that discount. Mirrors the non-active branch of the button
+ * delegation handler.
  */
 function createDiscountSelect(
     skillName: string,
@@ -303,9 +339,9 @@ export function renderSkills(): void {
         discountButtonGroup.className = 'discount-options flex gap-1 items-center'
         discountButtonGroup.dataset.skill = skillName
 
-        // Mobile gets a dropdown (the button row is too wide for narrow
-        // screens); desktop keeps the one-tap button row.
-        if (isMobileViewport()) {
+        // A narrow skills pane gets a dropdown (the button row is too wide to
+        // fit next to the skill name); a wide pane keeps the one-tap button row.
+        if (shouldUseDiscountDropdown()) {
             discountButtonGroup.appendChild(
                 createDiscountSelect(skillName, currentDiscount),
             )


### PR DESCRIPTION
- The per-skill discount control now collapses from the button row to a
  dropdown based on the skills pane's own width rather than the full window
  width, so a narrowed (resized) desktop pane collapses too. A ResizeObserver
  re-renders the skills list when the pane crosses the threshold.
- The results table renders at full size; the entire table + uma + track view
  scrolls as one unit instead of scrolling the table inside a fixed-height box.