### PR TITLE
Scroll results table and uma/race box as one full-height unit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,17 @@ Web interface for Uma Musume skill efficiency calculations. Calculates mean leng
 
 Fully client-side static site deployed to GitHub Pages. Simulations run in browser Web Workers, configs persist in IndexedDB.
 
+## Environment Setup
+
+Running in an ephemeral Cloud / CI container (Claude Code on the web, GitHub
+Actions, fresh clone) has gotchas that the README "Getting Started" glosses over
+— `node_modules` is absent, submodules need init, and the nested
+`uma-skill-tools` must be pinned to a loose commit that a plain `git fetch`
+won't retrieve. See **[docs/cloud-setup.md](docs/cloud-setup.md)** for the full
+step-by-step (install → submodule init → pin `24f0a88` via full SHA → build),
+plus how to drive a headless browser for UI verification and which `git status`
+noise is expected.
+
 ## Commands
 
 ```bash
@@ -83,7 +94,7 @@ npx tsx race-check.ts --races path/to/races.json --sims 200
 
 - `./uma-tools` is a git submodule (clone with `--recursive`)
 - `./uma-tools/uma-skill-tools/` is derived from <https://github.com/alpha123/uma-skill-tools> - understanding this code helps when working on simulation logic, but **never modify it**; pull latest from upstream instead
-- `uma-skill-tools` is pinned to commit `24f0a88`, which is one commit ahead of upstream `master` (`8b3f5e2` as of 2026-05). The pin carries two changes we depend on that haven't merged upstream: the `otherHorse()` API used by `uma-tools/umalator/compare.ts`, and the move of `mood`/`popularity` from `RaceParameters` onto `HorseParameters`. The parent `uma-tools` submodule still records an older `uma-skill-tools` commit (`6ba5ca0`), so a vanilla `git submodule update --recursive` lands ~9 commits before the pin — CI and `start_web.ps1` re-checkout `24f0a88` after init for that reason. Verify locally: `git -C uma-tools/uma-skill-tools rev-parse HEAD`
+- `uma-skill-tools` is pinned to commit `24f0a88`, which is one commit ahead of upstream `master` (`8b3f5e2` as of 2026-05). The pin carries two changes we depend on that haven't merged upstream: the `otherHorse()` API used by `uma-tools/umalator/compare.ts`, and the move of `mood`/`popularity` from `RaceParameters` onto `HorseParameters`. The parent `uma-tools` submodule still records an older `uma-skill-tools` commit (`6ba5ca0`), so a vanilla `git submodule update --recursive` lands ~9 commits before the pin — CI and `start_web.ps1` re-checkout `24f0a88` after init for that reason. Note a plain `git fetch` will not retrieve `24f0a88` (it is not a branch tip); fetch the full SHA: `git -C uma-tools/uma-skill-tools fetch origin 24f0a8862106dd4aaeea55e90e975acc9ca5d019 && git -C uma-tools/uma-skill-tools checkout 24f0a8862106dd4aaeea55e90e975acc9ca5d019`. Verify locally: `git -C uma-tools/uma-skill-tools rev-parse HEAD`. Full setup walkthrough in [docs/cloud-setup.md](docs/cloud-setup.md).
 - Ignore type checking errors from `./uma-tools` package. Our own files type-check cleanly; `mood` and `popularity` flow through `baseUma` (HorseParameters) end-to-end, matching the post-24f0a88 API.
 - `driver.js` (npm dependency) powers the onboarding tour in `public/tour.ts`. CSS is imported in the same file (`driver.js/dist/driver.css`).
 

--- a/docs/cloud-setup.md
+++ b/docs/cloud-setup.md
@@ -1,0 +1,193 @@
+# Setting up Umalator in a Cloud / CI environment
+
+This guide is for running Umalator in an **ephemeral, headless Linux
+environment** — Claude Code on the web, a GitHub Action, a fresh container, etc.
+— where the repository is cloned fresh, `node_modules` is absent, and there is no
+display. For everyday local development on your own machine, the
+[README](../README.md) "Getting Started" section is enough; this doc covers the
+extra steps and gotchas that bite in automation.
+
+> TL;DR — the four steps that must all happen before anything works:
+>
+> ```bash
+> npm install
+> git submodule update --init --recursive
+> # CRITICAL: pin the nested submodule to the exact commit we depend on
+> ( cd uma-tools/uma-skill-tools \
+>   && git fetch origin 24f0a8862106dd4aaeea55e90e975acc9ca5d019 \
+>   && git checkout 24f0a8862106dd4aaeea55e90e975acc9ca5d019 )
+> npm run build
+> ```
+
+## Prerequisites: network access
+
+The remote environment's network policy must allow outbound HTTPS to:
+
+- **github.com** — to clone the `uma-tools` submodule and fetch the pinned
+  `uma-skill-tools` commit.
+- **the upstream uma-tools raw data host** — `npm run build` fetches the latest
+  `skill_data.json` / `skill_meta.json` from upstream. If the fetch fails it
+  falls back to the local copies, so a build still succeeds offline, but the
+  bundled game data may be stale.
+- **the npm registry** — for `npm install`.
+
+If you are configuring a Claude Code on the web environment, pick a network
+policy that permits these. See
+<https://code.claude.com/docs/en/claude-code-on-the-web>.
+
+## Step 1 — Install npm dependencies
+
+A fresh container has no `node_modules`:
+
+```bash
+npm install      # or `npm ci` if package-lock.json is trusted/unchanged
+```
+
+## Step 2 — Initialise the submodules
+
+```bash
+git submodule update --init --recursive
+```
+
+This lands `uma-tools/uma-skill-tools` on the commit the parent `uma-tools`
+records (`6ba5ca0` as of writing), which is **not** the commit we need. Do not
+skip Step 3.
+
+## Step 3 — Pin `uma-skill-tools` to `24f0a88` (the easy-to-miss step)
+
+We depend on commit `24f0a88`, which is **one commit ahead of upstream
+`uma-skill-tools` master**. It carries two changes our code relies on:
+
+- the `otherHorse()` API used by `uma-tools/umalator/compare.ts`, and
+- the move of `mood` / `popularity` from `RaceParameters` onto
+  `HorseParameters`.
+
+Because `24f0a88` is a loose commit that is not the tip of any branch, a plain
+`git fetch` will **not** retrieve it, and `git checkout 24f0a88` fails with
+`pathspec '24f0a88' did not match any file(s) known to git`. You must fetch the
+**full 40-character SHA** explicitly:
+
+```bash
+cd uma-tools/uma-skill-tools
+git fetch origin 24f0a8862106dd4aaeea55e90e975acc9ca5d019
+git checkout 24f0a8862106dd4aaeea55e90e975acc9ca5d019
+cd ../..
+
+# Verify:
+git -C uma-tools/uma-skill-tools rev-parse HEAD
+# -> 24f0a8862106dd4aaeea55e90e975acc9ca5d019
+```
+
+This is exactly what `.github/workflows/deploy.yml` and `start_web.ps1` do after
+submodule init. After this checkout, `git status` will show
+`m uma-tools` ("modified content") forever — that is the **expected** state, not
+something to commit. See [Cleanup](#cleanup-expected-git-noise) below.
+
+### Symptom if you skip Step 3
+
+With the submodule stuck on `6ba5ca0`, `npm run build` / `vite` still transpile
+(esbuild and `tsx` do not type-check), but:
+
+- `npx tsc --noEmit` reports type errors in our own files where `mood` /
+  `popularity` flow through `HorseParameters` (the pre-`24f0a88` types differ),
+  and
+- running an actual simulation can fail at runtime because `otherHorse()` is
+  missing.
+
+## Step 4 — Build the workers and copy data
+
+```bash
+npm run build
+```
+
+`tsx build.ts` fetches the latest game data, builds the Node worker
+(`simulation.worker.js`) and the browser worker
+(`static/simulation.browser-worker.js`), and copies the JSON data files into
+`static/data/`. Run this **before** `npm test`, `npx vite`, or the CLI.
+
+## Running the tests
+
+```bash
+npm test                       # full suite (vitest run)
+npx vitest run utils.test.ts   # a single file
+```
+
+`simulation-runner.test.ts` exercises the Node worker, so it needs Steps 3–4
+done first. The pure-function tests (`utils.test.ts`, `public/*.test.ts`) do not.
+
+## Type checking — caveat
+
+The CLAUDE.md command is `npx tsc --noEmit`, but be aware the root `tsconfig.json`
+enables `noUncheckedIndexedAccess` and currently surfaces a number of
+`possibly 'undefined'` errors across our own files (an in-progress cleanup —
+see issue #63). Type errors do **not** block `npm run build`/`vite`/`npm test`,
+because none of those type-check. Treat `tsc` output as advisory and scope your
+review to the files you changed rather than expecting a clean exit.
+
+## Visual / UI verification in a headless environment
+
+There is no browser or display, so to confirm a UI or layout change you drive the
+Vite dev server with a headless browser (Playwright works well):
+
+```bash
+# 1. Install a headless browser once (chromium-headless-shell is enough):
+npm i -D playwright
+PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers npx playwright install chromium
+
+# 2. Start the dev server in the background:
+nohup npx vite > /tmp/vite.log 2>&1 &
+#    (npx vite alone serves the already-built workers; `npm run dev` rebuilds first)
+
+# 3. Drive it from a script (see example below) and screenshot.
+PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers node shot.mjs
+```
+
+A minimal screenshot driver:
+
+```js
+import { chromium } from 'playwright'
+const b = await chromium.launch()
+const p = await b.newPage({ viewport: { width: 1280, height: 720 } })
+await p.goto('http://localhost:5173/', { waitUntil: 'networkidle' })
+await p.keyboard.press('Escape') // dismiss the first-visit onboarding tour
+// To exercise layout with lots of rows without running a simulation, inject
+// fake <tr>s into #results-tbody here, then screenshot.
+await p.screenshot({ path: 'out.png' })
+await b.close()
+```
+
+Notes:
+
+- **Layout/CSS changes** can be verified by injecting placeholder rows into
+  `#results-tbody` — you do not need a working simulation, so Step 3 is optional
+  for pure layout work (but still recommended).
+- **Simulation behaviour** must go through the real worker, which requires
+  Steps 3–4.
+- The onboarding tour (driver.js) auto-opens on first visit; press `Escape` (or
+  clear `localStorage["umalator:tour-seen"]` expectations) so it doesn't cover
+  the UI in screenshots.
+- Remember to install `playwright` only as a throwaway dev tool; do not commit
+  it to `package.json`. Revert `package.json` / `package-lock.json` before
+  committing your actual change.
+
+## Cleanup: expected git noise
+
+After Step 3, `git status` shows:
+
+```text
+ m uma-tools
+```
+
+This is the nested `uma-skill-tools` sitting on `24f0a88` while the parent
+`uma-tools` still records `6ba5ca0`. It is the **required** working state and
+must **not** be committed. When committing your changes, stage files explicitly
+(`git add <your files>`) rather than `git add -A`, so the submodule pointer and
+any throwaway tooling are left out. To return to a fully clean tree (e.g. before
+a Stop hook git check), restore the submodule:
+
+```bash
+git submodule update --init --recursive --force uma-tools
+```
+
+(Note: restoring like this puts `uma-skill-tools` back on `6ba5ca0`, so re-run
+Step 3 before running simulations again.)

--- a/public/index.html
+++ b/public/index.html
@@ -117,9 +117,9 @@
 
             <div
                 id="right-pane"
-                class="w-full flex-1 min-w-0 min-h-0 p-2.5 flex flex-col bg-zinc-900 overflow-y-auto"
+                class="w-full flex-1 min-w-0 min-h-0 p-2.5 flex flex-col bg-zinc-900 overflow-hidden"
             >
-                <div class="flex flex-wrap items-center gap-1.5 mb-2.5">
+                <div class="shrink-0 flex flex-wrap items-center gap-1.5 mb-2.5">
                     <select
                         id="config-select"
                         class="flex-1 min-w-0 py-1 px-1.5 bg-zinc-700 text-zinc-200 border border-zinc-600 rounded text-[13px] focus:outline-none focus:border-sky-500"
@@ -170,6 +170,14 @@
                     </button>
                 </div>
 
+                <!--
+                    Scroll wrapper: the results table + uma/race box scroll as a
+                    single unit when they don't fit. The table renders at full
+                    height (no internal vertical scroll), so the whole panel's
+                    content overflows here rather than squeezing the table into a
+                    fixed-height box.
+                -->
+                <div id="right-scroll" class="flex-1 min-h-0 overflow-y-auto">
                 <div
                     id="results-container"
                     class="bg-zinc-800 text-zinc-200 p-2.5 rounded-md text-sm leading-normal overflow-x-auto border border-zinc-700 mb-2.5"
@@ -212,6 +220,7 @@
                 >
                     <div id="uma-container"></div>
                     <div id="track-container"></div>
+                </div>
                 </div>
             </div>
         </div>

--- a/public/panelLayout.test.ts
+++ b/public/panelLayout.test.ts
@@ -1,0 +1,61 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+// The results pane must scroll as a single unit: the table renders at full
+// height and the table + uma/race box share one scrollbar when they overflow.
+// These invariants guard against the regression where `overflow-x-auto` on the
+// results container turned it into a vertical scroll box that flex-shrank,
+// trapping the table in a tiny scroll area while the panel itself never moved.
+const html = readFileSync(
+    fileURLToPath(new URL('./index.html', import.meta.url)),
+    'utf8',
+)
+
+function attrsOf(id: string): string {
+    const open = html.indexOf(`id="${id}"`)
+    expect(open, `#${id} should exist`).toBeGreaterThan(-1)
+    // Grab the class attribute of the element bearing this id.
+    const around = html.slice(html.lastIndexOf('<', open), html.indexOf('>', open))
+    const match = around.match(/class="([^"]*)"/)
+    return match ? match[1]! : ''
+}
+
+describe('results pane scroll layout', () => {
+    it('the right pane clips rather than scrolling itself', () => {
+        const cls = attrsOf('right-pane')
+        expect(cls).toContain('flex')
+        expect(cls).toContain('flex-col')
+        expect(cls).toContain('overflow-hidden')
+        expect(cls).not.toContain('overflow-y-auto')
+    })
+
+    it('a single inner scroller fills the remaining height', () => {
+        const cls = attrsOf('right-scroll')
+        expect(cls).toContain('flex-1')
+        expect(cls).toContain('min-h-0')
+        expect(cls).toContain('overflow-y-auto')
+    })
+
+    it('the results table and uma/race box live inside that scroller', () => {
+        const scrollerOpen = html.indexOf('id="right-scroll"')
+        const rightPaneOpen = html.indexOf('id="right-pane"')
+        // Everything that should scroll together must appear after the scroller
+        // opens and before the right pane closes.
+        for (const id of ['results-container', 'uma-container', 'track-container']) {
+            const at = html.indexOf(`id="${id}"`)
+            expect(at, `#${id} should exist`).toBeGreaterThan(scrollerOpen)
+            expect(at).toBeGreaterThan(rightPaneOpen)
+        }
+    })
+
+    it('keeps the results table free to render at full height', () => {
+        // The container may scroll horizontally for the wide table, but it must
+        // not be the vertical scroller — otherwise it flex-shrinks and traps the
+        // table. Vertical scrolling belongs to #right-scroll.
+        const cls = attrsOf('results-container')
+        expect(cls).toContain('overflow-x-auto')
+        expect(cls).not.toContain('overflow-y-auto')
+        expect(cls).not.toContain('flex-1')
+    })
+})


### PR DESCRIPTION
The results table was trapped in a small internal scroll box while the
uma/race box stayed pinned below it. Cause: the results container's
`overflow-x-auto` makes the browser compute `overflow-y: auto` too,
turning it into a vertical scroll container. As a default flex item it
then flex-shrank to absorb the panel's overflow, so the table scrolled
inside a squeezed box and the panel itself never scrolled.

Keep the control bar fixed and wrap the results table + uma/race box in a
single `flex-1 min-h-0 overflow-y-auto` scroller. The table now renders
at full height and the table + uma/race box share one scrollbar when the
content doesn't fit. Horizontal scrolling of the wide table is preserved
on the results container.

https://claude.ai/code/session_018XBu6MCLTyL65uZD6SdVLN