### PR TITLE
Persist & restore the last results per config

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,8 +180,8 @@ All skills receive 500 simulations.
 | Median | Median length gain from simulations |
 | Mean/Cost | Efficiency ratio (mean length / cost, x1000) |
 | Min-Max | Minimum and maximum length gains |
-| Range (`ciLower`/`ciUpper`) | Outcome spread: the central percentile band of per-race gains (e.g. 2.5–97.5% at 95%). How much the result swings race to race. |
-| Mean CI (`ciMeanLower`/`ciMeanUpper`) | Confidence interval of the mean gain (mean ± z·SE): how precisely the average is estimated. |
+| Range (`rangeLower`/`rangeUpper`) | Outcome spread: the central percentile band of per-race gains (e.g. 2.5–97.5% at 95%). How much the result swings race to race. |
+| Mean CI (`ciMeanLower`/`ciMeanUpper`) | Confidence interval of the mean gain (mean ± t·SE): how precisely the average is estimated. |
 
 Results are sorted by Mean/Cost in descending order.
 

--- a/public/app.ts
+++ b/public/app.ts
@@ -6,6 +6,7 @@ import './api'
 import { runCalculations } from './api'
 import {
     deleteConfig,
+    deleteResults,
     duplicateConfig,
     exportAllConfigs,
     exportConfig,
@@ -462,6 +463,9 @@ async function saveImportedConfig(
         })
         return
     }
+    // Drop any results persisted under this name: an import replaces the config,
+    // so the old results no longer describe it.
+    await deleteResults(filename)
     await loadConfigFiles()
     await loadConfig(filename)
     showToast({ type: 'info', message: summary })
@@ -687,6 +691,7 @@ async function handleConfigMenuAction(action: string): Promise<void> {
         }
         try {
             await deleteConfig(currentConfigFile)
+            await deleteResults(currentConfigFile)
             deleteConfigFromFilesystem(currentConfigFile)
             showToast({ type: 'info', message: `Deleted ${currentConfigFile}` })
             await loadConfigFiles()

--- a/public/configManager.ts
+++ b/public/configManager.ts
@@ -101,6 +101,8 @@ export async function loadConfig(filename: string): Promise<void> {
     }
 
     callRenderSkills()
+    // A freshly loaded config opens at the top of its skill list.
+    document.getElementById('skills-container')?.scrollTo({ top: 0 })
     renderTrack()
     callRenderUma()
     callRenderResults()

--- a/public/configManager.ts
+++ b/public/configManager.ts
@@ -1,13 +1,20 @@
 import * as configStore from './configStore'
 import { LAST_USED_CONFIG_KEY } from './constants'
 import { writeConfigToFilesystem } from './devConfigSync'
-import { callRenderSkills, callRenderUma } from './renderCallbacks'
+import {
+    callRenderResults,
+    callRenderSkills,
+    callRenderUma,
+} from './renderCallbacks'
 import { renderTrack, waitForCourseData } from './trackUI'
 import {
     clearSaveTimeout,
+    getCalculatedResultsCache,
     getCurrentConfig,
     getCurrentConfigFile,
     getPendingSavePromise,
+    getResultsMap,
+    getSelectedSkills,
     setCurrentConfig,
     setCurrentConfigFile,
     setPendingSavePromise,
@@ -75,9 +82,28 @@ export async function loadConfig(filename: string): Promise<void> {
         console.warn('Failed to save to localStorage:', e)
     }
 
+    // Restore this config's last calculated results (persisted per config) so
+    // they reappear instantly without recomputing. Clearing first scopes the
+    // results to the config being loaded.
+    const resultsMap = getResultsMap()
+    const calculatedResultsCache = getCalculatedResultsCache()
+    const selectedSkills = getSelectedSkills()
+    resultsMap.clear()
+    selectedSkills.clear()
+    calculatedResultsCache.clear()
+    try {
+        for (const result of await configStore.loadResults(filename)) {
+            calculatedResultsCache.set(result.skill, result)
+            resultsMap.set(result.skill, { ...result, status: 'cached' })
+        }
+    } catch (e: unknown) {
+        console.warn('Failed to restore results:', e)
+    }
+
     callRenderSkills()
     renderTrack()
     callRenderUma()
+    callRenderResults()
 }
 
 export async function saveConfig(): Promise<void> {

--- a/public/configStore.ts
+++ b/public/configStore.ts
@@ -127,6 +127,9 @@ export async function duplicateConfig(
 ): Promise<void> {
     const config = await loadConfig(from)
     await saveConfig(to, config)
+    // Carry the cached results over so the duplicate shows the same table
+    // immediately instead of an empty one.
+    await saveResults(to, await loadResults(from))
 }
 
 /** Persist the last calculated results for a config (keyed by config name). */

--- a/public/configStore.ts
+++ b/public/configStore.ts
@@ -2,11 +2,14 @@
  * IndexedDB-backed config storage for static hosting.
  * Replaces server-side filesystem config management.
  */
-import type { Config } from './types'
+import type { Config, SkillResult } from './types'
 
 const DB_NAME = 'umalator'
-const DB_VERSION = 1
+const DB_VERSION = 2
 const STORE_NAME = 'configs'
+// Last calculated results per config, so they reappear instantly on load
+// without recomputing.
+const RESULTS_STORE = 'results'
 
 let cachedDb: IDBDatabase | null = null
 
@@ -18,6 +21,9 @@ function openDb(): Promise<IDBDatabase> {
             const db = request.result
             if (!db.objectStoreNames.contains(STORE_NAME)) {
                 db.createObjectStore(STORE_NAME)
+            }
+            if (!db.objectStoreNames.contains(RESULTS_STORE)) {
+                db.createObjectStore(RESULTS_STORE)
             }
         }
         request.onsuccess = () => {
@@ -121,6 +127,46 @@ export async function duplicateConfig(
 ): Promise<void> {
     const config = await loadConfig(from)
     await saveConfig(to, config)
+}
+
+/** Persist the last calculated results for a config (keyed by config name). */
+export async function saveResults(
+    name: string,
+    results: SkillResult[],
+): Promise<void> {
+    const db = await openDb()
+    return new Promise((resolve, reject) => {
+        const tx = db.transaction(RESULTS_STORE, 'readwrite')
+        const request = tx.objectStore(RESULTS_STORE).put(results, name)
+        request.onsuccess = () => resolve()
+        request.onerror = () => reject(request.error)
+    })
+}
+
+/** Load a config's last calculated results, or [] if none are stored. */
+export async function loadResults(name: string): Promise<SkillResult[]> {
+    const db = await openDb()
+    return new Promise((resolve, reject) => {
+        const tx = db.transaction(RESULTS_STORE, 'readonly')
+        const request = tx.objectStore(RESULTS_STORE).get(name)
+        request.onsuccess = () =>
+            resolve(
+                Array.isArray(request.result)
+                    ? (request.result as SkillResult[])
+                    : [],
+            )
+        request.onerror = () => reject(request.error)
+    })
+}
+
+export async function deleteResults(name: string): Promise<void> {
+    const db = await openDb()
+    return new Promise((resolve, reject) => {
+        const tx = db.transaction(RESULTS_STORE, 'readwrite')
+        const request = tx.objectStore(RESULTS_STORE).delete(name)
+        request.onsuccess = () => resolve()
+        request.onerror = () => reject(request.error)
+    })
 }
 
 export function exportConfig(name: string, config: Config): void {
@@ -249,6 +295,9 @@ export function importConfig(file: File): Promise<{ name: string; config: Config
                     ? file.name
                     : `${file.name}.json`
                 await saveConfig(name, config)
+                // An import replaces the config, so any results stored under
+                // this name no longer describe it.
+                await deleteResults(name)
                 resolve({ name, config })
             } catch (error) {
                 reject(error)

--- a/public/index.html
+++ b/public/index.html
@@ -242,7 +242,7 @@
                                 <th scope="col" class="p-1 cursor-pointer hover:text-teal-300 text-right" data-sort="meanLengthPerCost" title="Efficiency: mean length gained per skill point (×1000)">Mean/Cost</th>
                                 <th scope="col" class="p-1 text-right" title="Smallest and largest single-race gain observed">Min-Max</th>
                                 <th scope="col" class="p-1 text-right" title="Outcome spread: the central percentile band of per-race gains (e.g. 2.5–97.5%). How much the result swings race to race.">Range</th>
-                                <th scope="col" class="p-1 text-right" title="Confidence interval of the mean gain (mean ± z × standard error): how precisely the average is estimated.">Mean CI</th>
+                                <th scope="col" class="p-1 text-right" title="Confidence interval of the mean gain (mean ± t × standard error): how precisely the average is estimated.">Mean CI</th>
                             </tr>
                         </thead>
                         <tbody id="results-tbody"></tbody>

--- a/public/renderCallbacks.ts
+++ b/public/renderCallbacks.ts
@@ -5,6 +5,7 @@ type RenderCallback = () => void
 
 let renderUmaCallback: RenderCallback | null = null
 let renderSkillsCallback: RenderCallback | null = null
+let renderResultsCallback: RenderCallback | null = null
 
 export function registerRenderUma(callback: RenderCallback): void {
     renderUmaCallback = callback
@@ -12,6 +13,10 @@ export function registerRenderUma(callback: RenderCallback): void {
 
 export function registerRenderSkills(callback: RenderCallback): void {
     renderSkillsCallback = callback
+}
+
+export function registerRenderResults(callback: RenderCallback): void {
+    renderResultsCallback = callback
 }
 
 export function callRenderUma(): void {
@@ -23,5 +28,11 @@ export function callRenderUma(): void {
 export function callRenderSkills(): void {
     if (renderSkillsCallback) {
         renderSkillsCallback()
+    }
+}
+
+export function callRenderResults(): void {
+    if (renderResultsCallback) {
+        renderResultsCallback()
     }
 }

--- a/public/resultsUI.ts
+++ b/public/resultsUI.ts
@@ -241,7 +241,7 @@ export function renderResultsTable(): void {
         rangeCell.textContent =
             result.status === 'pending'
                 ? '...'
-                : formatInterval(result.ciLower, result.ciUpper)
+                : formatInterval(result.rangeLower, result.rangeUpper)
         row.appendChild(rangeCell)
 
         // Mean CI: confidence interval of the mean gain (precision of the mean).
@@ -572,8 +572,8 @@ export function addPendingSkillToResults(
         meanLengthPerCost: 0,
         minLength: 0,
         maxLength: 0,
-        ciLower: 0,
-        ciUpper: 0,
+        rangeLower: 0,
+        rangeUpper: 0,
         ciMeanLower: 0,
         ciMeanUpper: 0,
         status: 'pending',

--- a/public/resultsUI.ts
+++ b/public/resultsUI.ts
@@ -1,5 +1,10 @@
+import { saveResults } from './configStore'
 import { autoSave } from './configManager'
-import { callRenderSkills, callRenderUma } from './renderCallbacks'
+import {
+    callRenderSkills,
+    callRenderUma,
+    registerRenderResults,
+} from './renderCallbacks'
 import {
     adjustSkillPoints,
     createSkillIcon,
@@ -13,6 +18,7 @@ import {
 import {
     getCalculatedResultsCache,
     getCurrentConfig,
+    getCurrentConfigFile,
     getLastCalculationTime,
     getResultsMap,
     getSelectedSkills,
@@ -33,6 +39,33 @@ import type { SkillResult, SkillResultWithStatus } from './types'
 // Render a "lo-hi" interval to two decimals.
 function formatInterval(lo: number, hi: number): string {
     return `${lo.toFixed(2)}-${hi.toFixed(2)}`
+}
+
+// Persist the current table to IndexedDB (debounced) so it reappears on the next
+// load without recomputing. Only completed rows are stored; pending/error rows
+// are transient. Keyed by the open config.
+let resultsSaveTimeout: ReturnType<typeof setTimeout> | null = null
+function persistResults(): void {
+    if (resultsSaveTimeout) clearTimeout(resultsSaveTimeout)
+    resultsSaveTimeout = setTimeout(() => {
+        resultsSaveTimeout = null
+        const configFile = getCurrentConfigFile()
+        if (!configFile) return
+        const results: SkillResult[] = []
+        for (const row of getResultsMap().values()) {
+            if (row.status === 'pending' || row.status === 'error') continue
+            const {
+                status: _status,
+                rawResults: _rawResults,
+                errorMessage: _errorMessage,
+                ...plain
+            } = row
+            results.push(plain)
+        }
+        void saveResults(configFile, results).catch((error) => {
+            console.warn('Failed to persist results:', error)
+        })
+    }, 500)
 }
 
 // Forward declaration to avoid circular import - will be set by api.ts
@@ -82,6 +115,7 @@ export function renderResultsTable(): void {
     if (results.length === 0) {
         if (countEl) countEl.textContent = 'No results yet'
         updateTotalsRow()
+        persistResults()
         return
     }
 
@@ -234,7 +268,12 @@ export function renderResultsTable(): void {
     }
 
     updateTotalsRow()
+    persistResults()
 }
+
+// Re-render the results table from the current state. Registered so config
+// loading can restore persisted results without a circular import.
+registerRenderResults(renderResultsTable)
 
 export function updateTotalsRow(): void {
     const resultsMap = getResultsMap()

--- a/public/skillsUI.ts
+++ b/public/skillsUI.ts
@@ -232,7 +232,7 @@ function createDiscountSelect(
     select.addEventListener('change', () => {
         const discount = select.value === '-' ? null : parseInt(select.value, 10)
         setDiscountForVariants(skillName, discount)
-        renderSkills()
+        refreshAffectedSkillRows(skillName)
         autoSave()
     })
 
@@ -244,9 +244,13 @@ export function renderSkills(): void {
     if (!currentConfig) return
     const container = document.getElementById('skills-container')
     if (!container) return
+    // Full rebuilds (filters, add-to-uma, rename, resize) keep the scroll
+    // position so the pane doesn't jump to the top. Discount/default toggles
+    // skip the rebuild entirely via refreshAffectedSkillRows(). Config switches
+    // reset to the top explicitly in loadConfig().
+    const scrollTop = container.scrollTop
     container.innerHTML = ''
     const skills = currentConfig.skills
-    const umaSkills = currentConfig.uma?.skills || []
 
     const skillNames = Object.keys(skills)
     const skillsToRender = new Set<string>()
@@ -323,271 +327,319 @@ export function renderSkills(): void {
     syncFilterControls()
 
     triggerableSkills.forEach((skillName) => {
-        const skill = skills[skillName]
-        if (!skill) return
-
-        if (skill.discount === undefined) {
-            skill.discount = null
-        }
-
-        const div = document.createElement('div')
-        div.className =
-            'flex items-center gap-2 hover:bg-zinc-800 px-1 py-0.5 rounded'
-        div.dataset.skill = skillName
-
-        const currentDiscount = skill.discount
-
-        // Lock state: is the current discount the config's saved default? When
-        // it is, the active discount highlights green (rather than the usual
-        // blue) to signal the value is locked to the default.
-        const skillDefault = skill.default
-        const isDefaultActive =
-            skillDefault !== undefined &&
-            skillDefault !== null &&
-            currentDiscount === skillDefault
-        const isDefaultNull =
-            (skillDefault === undefined || skillDefault === null) &&
-            (currentDiscount === null || currentDiscount === undefined)
-        const isLocked = isDefaultActive || isDefaultNull
-        const activeDiscountClass = isLocked
-            ? `${squareClasses} bg-green-600 text-white border border-green-600 hover:bg-green-700 hover:border-green-700`
-            : `${squareClasses} bg-sky-600 text-white border border-sky-600 hover:bg-sky-700 hover:border-sky-700`
-
-        const discountButtonGroup = document.createElement('div')
-        discountButtonGroup.className = 'discount-options flex gap-1 items-center'
-        discountButtonGroup.dataset.skill = skillName
-
-        // A narrow skills pane gets a dropdown (the button row is too wide to
-        // fit next to the skill name); a wide pane keeps the one-tap button row.
-        if (shouldUseDiscountDropdown()) {
-            discountButtonGroup.appendChild(
-                createDiscountSelect(skillName, currentDiscount, isLocked),
-            )
-        } else {
-            DISCOUNT_OPTIONS.forEach((value) => {
-                const button = document.createElement('button')
-                button.className = `${squareClasses} bg-zinc-700 text-zinc-200 border border-zinc-600 hover:bg-zinc-600 hover:border-zinc-500`
-                button.dataset.skill = skillName
-                button.dataset.discount = value === null ? '-' : value.toString()
-                button.textContent = value === null ? '-' : value.toString()
-                if (
-                    currentDiscount === value ||
-                    (value === null &&
-                        (currentDiscount === null ||
-                            currentDiscount === undefined))
-                ) {
-                    button.className = activeDiscountClass
-                }
-                discountButtonGroup.appendChild(button)
-            })
-        }
-
-        const lockButton = document.createElement('button')
-        lockButton.className = `lock-btn ${squareClasses} bg-transparent text-zinc-500 border-none hover:text-zinc-200 hover:bg-zinc-700`
-        lockButton.dataset.skill = skillName
-        lockButton.textContent = isLocked ? '🔒' : '🔓'
-        lockButton.title = isLocked
-            ? 'Remove default'
-            : 'Set current discount as default'
-        lockButton.addEventListener('click', (e) => {
-            e.stopPropagation()
-            const target = e.target as HTMLElement
-            const skillName = target.dataset.skill
-            const currentConfig = getCurrentConfig()
-            if (!skillName || !currentConfig) return
-            const currentDiscount = currentConfig.skills[skillName]?.discount
-            const skillDefault = currentConfig.skills[skillName]?.default
-            const isCurrentlyDefault =
-                (skillDefault !== undefined &&
-                    skillDefault !== null &&
-                    currentDiscount === skillDefault) ||
-                ((skillDefault === undefined || skillDefault === null) &&
-                    (currentDiscount === null || currentDiscount === undefined))
-            if (isCurrentlyDefault) {
-                updateSkillVariantsDefault(skillName, 'remove')
-            } else if (
-                currentDiscount === null ||
-                currentDiscount === undefined
-            ) {
-                updateSkillVariantsDefault(skillName, 'remove')
-            } else {
-                updateSkillVariantsDefault(skillName, 'set', currentDiscount)
-            }
-            renderSkills()
-            autoSave()
-        })
-        discountButtonGroup.appendChild(lockButton)
-
-        const addToUmaButton = document.createElement('button')
-        const isInUmaSkills = umaSkills.includes(skillName)
-        const hasDiscount =
-            skill.discount !== null && skill.discount !== undefined
-        if (isInUmaSkills) {
-            addToUmaButton.className = `add-to-uma-btn ${squareClasses} bg-red-600 text-white border-none hover:bg-red-700`
-            addToUmaButton.textContent = '-'
-            addToUmaButton.title = 'Remove from Uma skills'
-        } else {
-            if (hasDiscount) {
-                addToUmaButton.className = `add-to-uma-btn ${squareClasses} bg-sky-600 text-white border-none hover:bg-sky-700`
-            } else {
-                addToUmaButton.className = `add-to-uma-btn ${squareClasses} opacity-40 bg-zinc-700 text-zinc-400 border border-zinc-600 hover:bg-zinc-600 hover:border-zinc-500`
-            }
-            addToUmaButton.textContent = '+'
-            addToUmaButton.title = 'Add to Uma skills'
-        }
-        addToUmaButton.dataset.skill = skillName
-        addToUmaButton.addEventListener('click', (e) => {
-            e.stopPropagation()
-            const target = e.target as HTMLElement
-            const skillName = target.dataset.skill
-            const currentConfig = getCurrentConfig()
-            if (!skillName || !currentConfig) return
-            if (!currentConfig.uma) {
-                currentConfig.uma = {}
-            }
-            if (!currentConfig.uma.skills) {
-                currentConfig.uma.skills = []
-            }
-
-            const currentlyInUmaSkills =
-                currentConfig.uma.skills.includes(skillName)
-            if (currentlyInUmaSkills) {
-                // Removing skill
-                removeSkillFromUma(skillName)
-            } else {
-                // Adding skill
-                const cost = getSkillCostWithDiscount(skillName)
-                addSkillToUmaFromTable(skillName, cost)
-            }
-            callRenderUma()
-            renderSkills()
-            autoSave()
-        })
-
-        const skillNameSpan = document.createElement('span')
-        // truncate (with min-w-0 up the flex chain) keeps each skill on a single
-        // line and ellipsizes overflow instead of wrapping to a taller row.
-        skillNameSpan.className =
-            'skill-name-span flex-1 min-w-0 truncate cursor-pointer hover:text-teal-400'
-        skillNameSpan.textContent = skillName
-        // Tooltip shows the skill's effect/condition summary; falls back to
-        // the edit hint when no description is available (unknown name,
-        // skill data not loaded yet).
-        skillNameSpan.title =
-            describeSkill(skillName) ?? 'Click to edit skill name'
-        skillNameSpan.dataset.skill = skillName
-        skillNameSpan.addEventListener('click', (e) => {
-            e.stopPropagation()
-            const target = e.target as HTMLElement
-            const skillName = target.dataset.skill
-            const currentConfig = getCurrentConfig()
-            if (!skillName || !currentConfig) return
-            const originalName = skillName
-            const skillNameInput = document.createElement('input')
-            skillNameInput.type = 'text'
-            skillNameInput.className =
-                'py-0.5 px-1 border-sky-500 min-w-[100px] m-0 bg-zinc-700 text-zinc-200 border rounded text-[13px] focus:outline-none focus:border-sky-400 flex-1'
-            skillNameInput.value = originalName
-            const spanTarget = e.target as HTMLElement
-            skillNameInput.style.width = `${spanTarget.offsetWidth}px`
-            skillNameInput.style.minWidth = '100px'
-
-            // Esc with empty/placeholder value deletes the skill directly and
-            // sets this flag so the blur (fired by renderSkills removing the
-            // input) doesn't re-run the canonicalization path on the stale value.
-            let cancelled = false
-
-            const restoreSpan = () => {
-                renderSkills()
-            }
-
-            const deleteAndCancel = () => {
-                cancelled = true
-                deleteSkill(originalName)
-                pruneFromResults(originalName)
-                renderSkills()
-                callRenderUma()
-                autoSave()
-            }
-
-            const handleBlur = () => {
-                if (cancelled) return
-                const inputName = skillNameInput.value.trim()
-                if (!inputName) {
-                    deleteAndCancel()
-                } else {
-                    const canonicalName = getCanonicalSkillName(inputName)
-                    if (!isValidSkillName(canonicalName)) {
-                        showToast({
-                            type: 'error',
-                            message: `Unknown skill: "${inputName}"`,
-                        })
-                        restoreSpan()
-                    } else if (
-                        canonicalName !== originalName &&
-                        !currentConfig.skills[canonicalName]
-                    ) {
-                        const skillData = currentConfig.skills[originalName]!
-                        deleteSkill(originalName)
-                        pruneFromResults(originalName)
-                        currentConfig.skills[canonicalName] = skillData
-                        renderSkills()
-                        callRenderUma()
-                        triggerCalculationForRenamedSkill(
-                            canonicalName,
-                            skillData.discount,
-                        )
-                        autoSave()
-                    } else {
-                        restoreSpan()
-                    }
-                }
-            }
-
-            const parent = spanTarget.parentNode
-            if (parent) {
-                parent.replaceChild(skillNameInput, spanTarget)
-            }
-            // Attach autocomplete BEFORE the input's own keydown listener so
-            // its Enter/Escape handlers can stopImmediatePropagation and beat
-            // the rename input's blur-on-Enter behavior.
-            attachSkillAutocomplete(skillNameInput, 'regular', {
-                getExclude: () =>
-                    Object.keys(getCurrentConfig()?.skills ?? {}),
-            })
-            skillNameInput.addEventListener('blur', handleBlur)
-            skillNameInput.addEventListener('keydown', (e) => {
-                if (e.key === 'Enter') {
-                    e.preventDefault()
-                    skillNameInput.blur()
-                } else if (e.key === 'Escape') {
-                    const value = skillNameInput.value.trim()
-                    const isPlaceholder = /^New Skill( \d+)?$/.test(value)
-                    if (!value || isPlaceholder) {
-                        deleteAndCancel()
-                    } else {
-                        restoreSpan()
-                    }
-                }
-            })
-            skillNameInput.focus()
-            skillNameInput.select()
-        })
-
-        const label = document.createElement('label')
-        label.className = 'flex-1 min-w-0 m-0 flex items-center gap-2'
-        const icon = createSkillIcon(skillName)
-        if (icon) label.appendChild(icon)
-        label.appendChild(skillNameSpan)
-
-        div.appendChild(addToUmaButton)
-        div.appendChild(label)
-        div.appendChild(discountButtonGroup)
-
-        container.appendChild(div)
+        const row = buildSkillRow(skillName)
+        if (row) container.appendChild(row)
     })
 
+    container.scrollTop = scrollTop
+
     // Event delegation is set up once via setupSkillsContainerDelegation()
+}
+
+/**
+ * Build one skill row: add-to-uma button, name label, and the discount button
+ * group with its lock toggle. Pure construction from current config state, so
+ * renderSkills() lays out the whole list and refreshAffectedSkillRows() can
+ * swap a single row in place after a discount/default change.
+ */
+function buildSkillRow(skillName: string): HTMLDivElement | null {
+    const currentConfig = getCurrentConfig()
+    if (!currentConfig) return null
+    const skill = currentConfig.skills[skillName]
+    if (!skill) return null
+    const umaSkills = currentConfig.uma?.skills || []
+
+    if (skill.discount === undefined) {
+        skill.discount = null
+    }
+
+    const div = document.createElement('div')
+    div.className =
+        'skill-row flex items-center gap-2 hover:bg-zinc-800 px-1 py-0.5 rounded'
+    div.dataset.skill = skillName
+
+    const currentDiscount = skill.discount
+
+    // Lock state: is the current discount the config's saved default? When
+    // it is, the active discount highlights green (rather than the usual
+    // blue) to signal the value is locked to the default.
+    const skillDefault = skill.default
+    const isDefaultActive =
+        skillDefault !== undefined &&
+        skillDefault !== null &&
+        currentDiscount === skillDefault
+    const isDefaultNull =
+        (skillDefault === undefined || skillDefault === null) &&
+        (currentDiscount === null || currentDiscount === undefined)
+    const isLocked = isDefaultActive || isDefaultNull
+    const activeDiscountClass = isLocked
+        ? `${squareClasses} bg-green-600 text-white border border-green-600 hover:bg-green-700 hover:border-green-700`
+        : `${squareClasses} bg-sky-600 text-white border border-sky-600 hover:bg-sky-700 hover:border-sky-700`
+
+    const discountButtonGroup = document.createElement('div')
+    discountButtonGroup.className = 'discount-options flex gap-1 items-center'
+    discountButtonGroup.dataset.skill = skillName
+
+    // A narrow skills pane gets a dropdown (the button row is too wide to
+    // fit next to the skill name); a wide pane keeps the one-tap button row.
+    if (shouldUseDiscountDropdown()) {
+        discountButtonGroup.appendChild(
+            createDiscountSelect(skillName, currentDiscount, isLocked),
+        )
+    } else {
+        DISCOUNT_OPTIONS.forEach((value) => {
+            const button = document.createElement('button')
+            button.className = `${squareClasses} bg-zinc-700 text-zinc-200 border border-zinc-600 hover:bg-zinc-600 hover:border-zinc-500`
+            button.dataset.skill = skillName
+            button.dataset.discount = value === null ? '-' : value.toString()
+            button.textContent = value === null ? '-' : value.toString()
+            if (
+                currentDiscount === value ||
+                (value === null &&
+                    (currentDiscount === null ||
+                        currentDiscount === undefined))
+            ) {
+                button.className = activeDiscountClass
+            }
+            discountButtonGroup.appendChild(button)
+        })
+    }
+
+    const lockButton = document.createElement('button')
+    lockButton.className = `lock-btn ${squareClasses} bg-transparent text-zinc-500 border-none hover:text-zinc-200 hover:bg-zinc-700`
+    lockButton.dataset.skill = skillName
+    lockButton.textContent = isLocked ? '🔒' : '🔓'
+    lockButton.title = isLocked
+        ? 'Remove default'
+        : 'Set current discount as default'
+    lockButton.addEventListener('click', (e) => {
+        e.stopPropagation()
+        const target = e.target as HTMLElement
+        const skillName = target.dataset.skill
+        const currentConfig = getCurrentConfig()
+        if (!skillName || !currentConfig) return
+        const currentDiscount = currentConfig.skills[skillName]?.discount
+        const skillDefault = currentConfig.skills[skillName]?.default
+        const isCurrentlyDefault =
+            (skillDefault !== undefined &&
+                skillDefault !== null &&
+                currentDiscount === skillDefault) ||
+            ((skillDefault === undefined || skillDefault === null) &&
+                (currentDiscount === null || currentDiscount === undefined))
+        if (isCurrentlyDefault) {
+            updateSkillVariantsDefault(skillName, 'remove')
+        } else if (
+            currentDiscount === null ||
+            currentDiscount === undefined
+        ) {
+            updateSkillVariantsDefault(skillName, 'remove')
+        } else {
+            updateSkillVariantsDefault(skillName, 'set', currentDiscount)
+        }
+        refreshAffectedSkillRows(skillName)
+        autoSave()
+    })
+    discountButtonGroup.appendChild(lockButton)
+
+    const addToUmaButton = document.createElement('button')
+    const isInUmaSkills = umaSkills.includes(skillName)
+    const hasDiscount =
+        skill.discount !== null && skill.discount !== undefined
+    if (isInUmaSkills) {
+        addToUmaButton.className = `add-to-uma-btn ${squareClasses} bg-red-600 text-white border-none hover:bg-red-700`
+        addToUmaButton.textContent = '-'
+        addToUmaButton.title = 'Remove from Uma skills'
+    } else {
+        if (hasDiscount) {
+            addToUmaButton.className = `add-to-uma-btn ${squareClasses} bg-sky-600 text-white border-none hover:bg-sky-700`
+        } else {
+            addToUmaButton.className = `add-to-uma-btn ${squareClasses} opacity-40 bg-zinc-700 text-zinc-400 border border-zinc-600 hover:bg-zinc-600 hover:border-zinc-500`
+        }
+        addToUmaButton.textContent = '+'
+        addToUmaButton.title = 'Add to Uma skills'
+    }
+    addToUmaButton.dataset.skill = skillName
+    addToUmaButton.addEventListener('click', (e) => {
+        e.stopPropagation()
+        const target = e.target as HTMLElement
+        const skillName = target.dataset.skill
+        const currentConfig = getCurrentConfig()
+        if (!skillName || !currentConfig) return
+        if (!currentConfig.uma) {
+            currentConfig.uma = {}
+        }
+        if (!currentConfig.uma.skills) {
+            currentConfig.uma.skills = []
+        }
+
+        const currentlyInUmaSkills =
+            currentConfig.uma.skills.includes(skillName)
+        if (currentlyInUmaSkills) {
+            // Removing skill
+            removeSkillFromUma(skillName)
+        } else {
+            // Adding skill
+            const cost = getSkillCostWithDiscount(skillName)
+            addSkillToUmaFromTable(skillName, cost)
+        }
+        callRenderUma()
+        renderSkills()
+        autoSave()
+    })
+
+    const skillNameSpan = document.createElement('span')
+    // truncate (with min-w-0 up the flex chain) keeps each skill on a single
+    // line and ellipsizes overflow instead of wrapping to a taller row.
+    skillNameSpan.className =
+        'skill-name-span flex-1 min-w-0 truncate cursor-pointer hover:text-teal-400'
+    skillNameSpan.textContent = skillName
+    // Tooltip shows the skill's effect/condition summary; falls back to
+    // the edit hint when no description is available (unknown name,
+    // skill data not loaded yet).
+    skillNameSpan.title =
+        describeSkill(skillName) ?? 'Click to edit skill name'
+    skillNameSpan.dataset.skill = skillName
+    skillNameSpan.addEventListener('click', (e) => {
+        e.stopPropagation()
+        const target = e.target as HTMLElement
+        const skillName = target.dataset.skill
+        const currentConfig = getCurrentConfig()
+        if (!skillName || !currentConfig) return
+        const originalName = skillName
+        const skillNameInput = document.createElement('input')
+        skillNameInput.type = 'text'
+        skillNameInput.className =
+            'py-0.5 px-1 border-sky-500 min-w-[100px] m-0 bg-zinc-700 text-zinc-200 border rounded text-[13px] focus:outline-none focus:border-sky-400 flex-1'
+        skillNameInput.value = originalName
+        const spanTarget = e.target as HTMLElement
+        skillNameInput.style.width = `${spanTarget.offsetWidth}px`
+        skillNameInput.style.minWidth = '100px'
+
+        // Esc with empty/placeholder value deletes the skill directly and
+        // sets this flag so the blur (fired by renderSkills removing the
+        // input) doesn't re-run the canonicalization path on the stale value.
+        let cancelled = false
+
+        const restoreSpan = () => {
+            renderSkills()
+        }
+
+        const deleteAndCancel = () => {
+            cancelled = true
+            deleteSkill(originalName)
+            pruneFromResults(originalName)
+            renderSkills()
+            callRenderUma()
+            autoSave()
+        }
+
+        const handleBlur = () => {
+            if (cancelled) return
+            const inputName = skillNameInput.value.trim()
+            if (!inputName) {
+                deleteAndCancel()
+            } else {
+                const canonicalName = getCanonicalSkillName(inputName)
+                if (!isValidSkillName(canonicalName)) {
+                    showToast({
+                        type: 'error',
+                        message: `Unknown skill: "${inputName}"`,
+                    })
+                    restoreSpan()
+                } else if (
+                    canonicalName !== originalName &&
+                    !currentConfig.skills[canonicalName]
+                ) {
+                    const skillData = currentConfig.skills[originalName]!
+                    deleteSkill(originalName)
+                    pruneFromResults(originalName)
+                    currentConfig.skills[canonicalName] = skillData
+                    renderSkills()
+                    callRenderUma()
+                    triggerCalculationForRenamedSkill(
+                        canonicalName,
+                        skillData.discount,
+                    )
+                    autoSave()
+                } else {
+                    restoreSpan()
+                }
+            }
+        }
+
+        const parent = spanTarget.parentNode
+        if (parent) {
+            parent.replaceChild(skillNameInput, spanTarget)
+        }
+        // Attach autocomplete BEFORE the input's own keydown listener so
+        // its Enter/Escape handlers can stopImmediatePropagation and beat
+        // the rename input's blur-on-Enter behavior.
+        attachSkillAutocomplete(skillNameInput, 'regular', {
+            getExclude: () =>
+                Object.keys(getCurrentConfig()?.skills ?? {}),
+        })
+        skillNameInput.addEventListener('blur', handleBlur)
+        skillNameInput.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter') {
+                e.preventDefault()
+                skillNameInput.blur()
+            } else if (e.key === 'Escape') {
+                const value = skillNameInput.value.trim()
+                const isPlaceholder = /^New Skill( \d+)?$/.test(value)
+                if (!value || isPlaceholder) {
+                    deleteAndCancel()
+                } else {
+                    restoreSpan()
+                }
+            }
+        })
+        skillNameInput.focus()
+        skillNameInput.select()
+    })
+
+    const label = document.createElement('label')
+    label.className = 'flex-1 min-w-0 m-0 flex items-center gap-2'
+    const icon = createSkillIcon(skillName)
+    if (icon) label.appendChild(icon)
+    label.appendChild(skillNameSpan)
+
+    div.appendChild(addToUmaButton)
+    div.appendChild(label)
+    div.appendChild(discountButtonGroup)
+
+    return div
+}
+
+/**
+ * Re-render only the rows touched by a discount/default change to `skillName`
+ * (the skill and its ○/◎ siblings), in place, leaving the rest of the list and
+ * the scroll position untouched. Falls back to a full renderSkills() when the
+ * change could alter which rows are shown: the Hint / No-Hint filter keys on
+ * whether a skill has a discount, which this change can flip.
+ */
+function refreshAffectedSkillRows(skillName: string): void {
+    const container = document.getElementById('skills-container')
+    const available = getAvailableFilter()
+    if (!container || available === 'hint' || available === 'noHint') {
+        renderSkills()
+        return
+    }
+    const affected = new Set<string>([
+        ...getDiscountVariants(skillName),
+        getBaseSkillName(skillName),
+    ])
+    for (const name of affected) {
+        const existing = container.querySelector<HTMLDivElement>(
+            `.skill-row[data-skill="${CSS.escape(name)}"]`,
+        )
+        if (!existing) continue
+        const replacement = buildSkillRow(name)
+        if (!replacement) {
+            renderSkills()
+            return
+        }
+        existing.replaceWith(replacement)
+    }
 }
 
 // Set up event delegation for discount buttons (single listener instead of per-button)
@@ -639,7 +691,7 @@ export function setupSkillsContainerDelegation(): void {
             setDiscountForVariants(skillName, discount)
         }
 
-        renderSkills()
+        refreshAffectedSkillRows(skillName)
         autoSave()
     })
 }

--- a/public/tour.ts
+++ b/public/tour.ts
@@ -125,7 +125,7 @@ function buildTour() {
                 popover: {
                     title: 'Reading the results',
                     description:
-                        'Mean and Median are length gain in m. Cost is base SP cost; Disc is your discount. Mean/Cost is the efficiency. Min-Max and 95% CI show the variance. Click headers to sort.',
+                        'Mean and Median are length gain in m. Cost is base SP cost; Disc is your discount. Mean/Cost is the efficiency. Min-Max is the extremes, Range is the spread of per-race outcomes, and Mean CI is how precisely the mean is estimated. Click headers to sort.',
                     side: 'top',
                 },
             },

--- a/public/types.ts
+++ b/public/types.ts
@@ -72,10 +72,10 @@ export interface SkillResult {
     minLength: number
     maxLength: number
     // Outcome spread: central percentile band of individual per-race results
-    // (not a CI of the mean). Named ciLower/ciUpper for historical reasons.
-    ciLower: number
-    ciUpper: number
-    // Confidence interval of the mean gain (mean ± z·SE).
+    // (not a CI of the mean).
+    rangeLower: number
+    rangeUpper: number
+    // Confidence interval of the mean gain (mean ± t·SE).
     ciMeanLower: number
     ciMeanUpper: number
 }

--- a/scripts/analyze-distributions.ts
+++ b/scripts/analyze-distributions.ts
@@ -1,0 +1,373 @@
+// Throwaway analysis: characterize the per-race gain distributions produced by
+// the AG.json skills and run a Monte-Carlo coverage study comparing 95% CI
+// methods for the mean at n=500. Not part of the build; safe to delete.
+import { readFileSync } from 'node:fs'
+import { cpus } from 'node:os'
+import { resolve } from 'node:path'
+import { Worker } from 'node:worker_threads'
+import type { RawCourseData, SimulationTask, SkillMeta } from '../types'
+import { standardNormalQuantile, type SkillDataEntry } from '../utils'
+import {
+    runSimulation,
+    type SimulationProgress,
+    type SimulationRunnerConfig,
+    type StaticData,
+    type TaskResult,
+    type WorkerAdapter,
+} from '../shared/simulation-orchestrator'
+
+const REF_SIMS = 20000 // reference "population" size per skill
+const N_SUB = 500 // the n the app actually uses
+const B_OUT = 800 // outer resamples in the coverage study
+const B_IN = 600 // inner bootstrap replicates
+const SEED = 0x5eed1234
+
+// ---- normal CDF (Abramowitz-Stegun 7.1.26) ---------------------------------
+function erf(x: number): number {
+    const t = 1 / (1 + 0.3275911 * Math.abs(x))
+    const y =
+        1 -
+        ((((1.061405429 * t - 1.453152027) * t + 1.421413741) * t -
+            0.284496736) *
+            t +
+            0.254829592) *
+            t *
+            Math.exp(-x * x)
+    return x >= 0 ? y : -y
+}
+function normalCdf(x: number): number {
+    return 0.5 * (1 + erf(x / Math.SQRT2))
+}
+
+// ---- seeded RNG (mulberry32) ----------------------------------------------
+function mulberry32(seed: number): () => number {
+    let a = seed >>> 0
+    return () => {
+        a |= 0
+        a = (a + 0x6d2b79f5) | 0
+        let t = Math.imul(a ^ (a >>> 15), 1 | a)
+        t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+    }
+}
+
+// ---- summary statistics ----------------------------------------------------
+interface Diag {
+    skill: string
+    n: number
+    mean: number
+    sd: number
+    min: number
+    max: number
+    range: number
+    median: number
+    pctZero: number
+    skew: number
+    exKurt: number
+    berryEsseen500: number
+}
+
+function diagnose(skill: string, x: number[]): Diag {
+    const n = x.length
+    const mean = x.reduce((a, b) => a + b, 0) / n
+    let m2 = 0
+    let m3 = 0
+    let m4 = 0
+    let absM3 = 0
+    let zero = 0
+    for (const v of x) {
+        const d = v - mean
+        m2 += d * d
+        m3 += d * d * d
+        m4 += d * d * d * d
+        absM3 += Math.abs(d) ** 3
+        if (Math.abs(v) < 1e-9) zero++
+    }
+    const varPop = m2 / n
+    const sdPop = Math.sqrt(varPop)
+    const sd = Math.sqrt(m2 / (n - 1))
+    const sorted = [...x].sort((a, b) => a - b)
+    const mid = Math.floor(n / 2)
+    const median = n % 2 === 0 ? (sorted[mid - 1]! + sorted[mid]!) / 2 : sorted[mid]!
+    const skew = sdPop > 0 ? m3 / n / sdPop ** 3 : 0
+    const exKurt = sdPop > 0 ? m4 / n / sdPop ** 4 - 3 : 0
+    // Berry-Esseen Gaussian-approximation error bound for Wald at n=500.
+    const rho = absM3 / n
+    const be = sdPop > 0 ? (0.48 * rho) / (sdPop ** 3 * Math.sqrt(N_SUB)) : 0
+    return {
+        skill,
+        n,
+        mean,
+        sd,
+        min: sorted[0]!,
+        max: sorted[n - 1]!,
+        range: sorted[n - 1]! - sorted[0]!,
+        median,
+        pctZero: (100 * zero) / n,
+        skew,
+        exKurt,
+        berryEsseen500: Math.min(be, 0.5),
+    }
+}
+
+// ---- CI methods (return [lo, hi]) -----------------------------------------
+const Z = standardNormalQuantile(0.975) // 1.95996
+const LN80 = Math.log(80)
+
+function meanSd(s: number[]): [number, number] {
+    const n = s.length
+    const m = s.reduce((a, b) => a + b, 0) / n
+    let q = 0
+    for (const v of s) q += (v - m) * (v - m)
+    return [m, Math.sqrt(q / (n - 1))]
+}
+
+function wald(m: number, sd: number, n: number): [number, number] {
+    const h = (Z * sd) / Math.sqrt(n)
+    return [m - h, m + h]
+}
+function hoeffding(m: number, n: number, range: number): [number, number] {
+    const h = range * Math.sqrt(Math.log(40) / (2 * n))
+    return [m - h, m + h]
+}
+function empBernstein(m: number, sd: number, n: number, range: number): [number, number] {
+    const h = sd * Math.sqrt((2 * LN80) / n) + (7 * range * LN80) / (3 * (n - 1))
+    return [m - h, m + h]
+}
+
+function sortedPercentile(sortedArr: number[], p: number): number {
+    const idx = Math.min(sortedArr.length - 1, Math.max(0, Math.floor(sortedArr.length * p)))
+    return sortedArr[idx]!
+}
+
+function bootstrapMeans(s: number[], b: number, rng: () => number): number[] {
+    const n = s.length
+    const means = new Array<number>(b)
+    for (let k = 0; k < b; k++) {
+        let sum = 0
+        for (let i = 0; i < n; i++) sum += s[(rng() * n) | 0]!
+        means[k] = sum / n
+    }
+    means.sort((a, b2) => a - b2)
+    return means
+}
+
+function percentileBoot(bootSorted: number[]): [number, number] {
+    return [sortedPercentile(bootSorted, 0.025), sortedPercentile(bootSorted, 0.975)]
+}
+
+function bca(s: number[], thetaHat: number, bootSorted: number[]): [number, number] {
+    const b = bootSorted.length
+    let less = 0
+    for (const v of bootSorted) if (v < thetaHat) less++
+    const frac = Math.min(b - 0.5, Math.max(0.5, less)) / b
+    const z0 = standardNormalQuantile(frac)
+    // jackknife acceleration
+    const n = s.length
+    const total = s.reduce((a, c) => a + c, 0)
+    const jk = new Array<number>(n)
+    let jkMean = 0
+    for (let i = 0; i < n; i++) {
+        jk[i] = (total - s[i]!) / (n - 1)
+        jkMean += jk[i]!
+    }
+    jkMean /= n
+    let num = 0
+    let den = 0
+    for (let i = 0; i < n; i++) {
+        const d = jkMean - jk[i]!
+        num += d * d * d
+        den += d * d
+    }
+    const a = den > 0 ? num / (6 * den ** 1.5) : 0
+    const zLo = -Z
+    const zHi = Z
+    const adj = (zt: number): number => {
+        const denom = 1 - a * (z0 + zt)
+        return normalCdf(z0 + (z0 + zt) / denom)
+    }
+    const a1 = adj(zLo)
+    const a2 = adj(zHi)
+    return [sortedPercentile(bootSorted, a1), sortedPercentile(bootSorted, a2)]
+}
+
+// ---- coverage study --------------------------------------------------------
+interface Cover {
+    method: string
+    coverage: number
+    meanHalfWidth: number
+    pctCrossZero: number
+}
+
+function coverageStudy(pop: number[], diag: Diag, rng: () => number): Cover[] {
+    const muPop = diag.mean
+    const range = diag.range
+    const methods = ['Wald-z', 'Hoeffding', 'Emp.Bernstein', 'Boot-pct', 'Boot-BCa']
+    const hit = methods.map(() => 0)
+    const width = methods.map(() => 0)
+    const crossZero = methods.map(() => 0)
+    const nPop = pop.length
+
+    for (let r = 0; r < B_OUT; r++) {
+        const sub = new Array<number>(N_SUB)
+        for (let i = 0; i < N_SUB; i++) sub[i] = pop[(rng() * nPop) | 0]!
+        const [m, sd] = meanSd(sub)
+        const bootSorted = bootstrapMeans(sub, B_IN, rng)
+        const intervals: [number, number][] = [
+            wald(m, sd, N_SUB),
+            hoeffding(m, N_SUB, range),
+            empBernstein(m, sd, N_SUB, range),
+            percentileBoot(bootSorted),
+            bca(sub, m, bootSorted),
+        ]
+        for (let j = 0; j < methods.length; j++) {
+            const [lo, hi] = intervals[j]!
+            if (lo <= muPop && muPop <= hi) hit[j]!++
+            width[j]! += (hi - lo) / 2
+            if (lo < 0 && hi > 0) crossZero[j]!++
+        }
+    }
+    return methods.map((method, j) => ({
+        method,
+        coverage: (100 * hit[j]!) / B_OUT,
+        meanHalfWidth: width[j]! / B_OUT,
+        pctCrossZero: (100 * crossZero[j]!) / B_OUT,
+    }))
+}
+
+// ---- run reference sims ----------------------------------------------------
+const dataDir = resolve('uma-tools/umalator-global')
+function loadJson<T>(path: string): T {
+    return JSON.parse(readFileSync(path, 'utf-8')) as T
+}
+const config = loadJson<SimulationRunnerConfig>(resolve('configs/AG.json'))
+config.numSimulations = REF_SIMS
+config.seed = 1234567
+const staticData: StaticData = {
+    courseData: loadJson<Record<string, RawCourseData>>(`${dataDir}/course_data.json`),
+    skillData: loadJson<Record<string, SkillDataEntry>>(`${dataDir}/skill_data.json`),
+    skillMeta: loadJson<Record<string, SkillMeta>>(`${dataDir}/skill_meta.json`),
+    skillNames: loadJson<Record<string, string[]>>(`${dataDir}/skillnames.json`),
+    trackNames: loadJson<Record<string, string[]>>(`${dataDir}/tracknames.json`),
+}
+
+const collector = new Map<string, number[]>()
+const workerPath = new URL('../simulation.worker.js', import.meta.url)
+function runNodeTask(task: SimulationTask): Promise<TaskResult> {
+    return new Promise((res, rej) => {
+        const worker = new Worker(workerPath, { workerData: task })
+        worker.on('message', (msg: { success: boolean; result?: TaskResult; error?: string }) => {
+            if (msg.success && msg.result) res(msg.result)
+            else rej(new Error(msg.error || 'fail'))
+            worker.terminate()
+        })
+        worker.on('error', (e) => {
+            rej(e)
+            worker.terminate()
+        })
+    })
+}
+const adapter: WorkerAdapter = {
+    concurrency: (n) => Math.min(n, cpus().length),
+    runTask: async (task) => {
+        const res = await runNodeTask(task)
+        if (res.rawResults) collector.set(res.skillName, res.rawResults)
+        return res
+    },
+}
+
+console.error(`Running ${REF_SIMS} reference sims per applicable skill...`)
+await runSimulation(
+    config,
+    staticData,
+    (p: SimulationProgress) => {
+        if (p.type === 'error') console.error('ERR', p.error)
+        if (p.type === 'info') console.error('INFO', p.info)
+    },
+    adapter,
+)
+
+// ---- diagnostics for every skill ------------------------------------------
+const diags: Diag[] = []
+for (const [skill, raw] of collector.entries()) {
+    if (raw.length > 1) diags.push(diagnose(skill, raw))
+}
+diags.sort((a, b) => a.pctZero - b.pctZero)
+
+console.log('\n=== DISTRIBUTION DIAGNOSTICS (all applicable AG.json skills) ===')
+console.log(
+    [
+        'skill',
+        'n',
+        'mean',
+        'sd',
+        'median',
+        'min',
+        'max',
+        '%zero',
+        'skew',
+        'exKurt',
+        'BE@500',
+    ].join('\t'),
+)
+for (const d of diags) {
+    console.log(
+        [
+            d.skill,
+            d.n,
+            d.mean.toFixed(4),
+            d.sd.toFixed(4),
+            d.median.toFixed(4),
+            d.min.toFixed(3),
+            d.max.toFixed(3),
+            d.pctZero.toFixed(1),
+            d.skew.toFixed(2),
+            d.exKurt.toFixed(2),
+            d.berryEsseen500.toFixed(3),
+        ].join('\t'),
+    )
+}
+
+// ---- pick representatives spanning the %zero / skew regimes ----------------
+function pick(name: string): Diag | undefined {
+    return diags.find((d) => d.skill === name)
+}
+const reps: Diag[] = []
+const seen = new Set<string>()
+// lowest %zero (most "filled in"), median, highest %zero, plus the highest-mean
+const byZero = [...diags]
+const byMean = [...diags].sort((a, b) => b.mean - a.mean)
+const candidates = [
+    byZero[0],
+    byZero[Math.floor(byZero.length / 2)],
+    byZero[byZero.length - 1],
+    byMean[0],
+    byMean[Math.floor(byMean.length / 4)],
+]
+for (const c of candidates) {
+    if (c && !seen.has(c.skill) && c.sd > 0) {
+        seen.add(c.skill)
+        reps.push(c)
+    }
+}
+
+console.log('\n=== COVERAGE STUDY (n=500, target 95%, ' + B_OUT + ' resamples) ===')
+console.log('Representatives:', reps.map((r) => r.skill).join(' | '))
+const rng = mulberry32(SEED)
+for (const d of reps) {
+    const pop = collector.get(d.skill)!
+    const rows = coverageStudy(pop, d, rng)
+    console.log(`\n--- ${d.skill}  (mean=${d.mean.toFixed(3)}, sd=${d.sd.toFixed(3)}, %zero=${d.pctZero.toFixed(1)}, skew=${d.skew.toFixed(2)}, range=${d.range.toFixed(2)}) ---`)
+    console.log(['method', 'coverage%', 'meanHalfWidth', '%crossZero'].join('\t'))
+    for (const row of rows) {
+        console.log(
+            [
+                row.method,
+                row.coverage.toFixed(1),
+                row.meanHalfWidth.toFixed(4),
+                row.pctCrossZero.toFixed(1),
+            ].join('\t'),
+        )
+    }
+}
+console.error('\nDone.')

--- a/scripts/ci-method-analysis.md
+++ b/scripts/ci-method-analysis.md
@@ -1,0 +1,101 @@
+# Confidence interval method for the Mean CI column
+
+This note records why the Mean CI column uses a Student `t_{n-1}` interval
+around the mean gain, and why the distribution-free and bootstrap alternatives
+were rejected. Reproduce with `npx tsx scripts/analyze-distributions.ts`.
+
+## Question
+
+The Mean CI reports `mean ± q · (s/√n)` for the per-race length gain. The
+per-race gain is bounded, so it is never exactly normal, which means there is no
+exact `t` interval available: every practical choice is asymptotic or
+conservative. The question is which choice best fits this use (a descriptive
+precision-of-the-mean stat, computed in the browser, shown next to a mean of
+order 0.1 to 1 length, at the default n = 500).
+
+## What the per-race gain distributions look like
+
+Reference sample: 19,975 sims per applicable AG.json skill (Pace Chaser,
+`<Mile>`, `<Random>` track, so each population is itself a mixture over 17
+courses and 5 moods).
+
+| skill | mean | sd | median | %zero | skew | exKurt |
+| --- | --- | --- | --- | --- | --- | --- |
+| Ignited Spirit SPD | 0.219 | 0.203 | 0.181 | 0.0 | +0.47 | 18.8 |
+| Ramp Up | 0.178 | 0.161 | 0.179 | 0.1 | −2.16 | 31.9 |
+| It's On! | 0.407 | 0.207 | 0.460 | 0.1 | −2.12 | 23.8 |
+| Triumphant Pulse | 0.451 | 0.066 | 0.455 | 0.2 | −0.93 | 7.1 |
+| Playtime's Over! | 0.315 | 0.185 | 0.322 | 1.0 | −1.36 | 25.7 |
+| Homestretch Haste | 0.186 | 0.068 | 0.211 | 2.4 | −1.17 | 0.5 |
+| Pace Chaser Straightaways ○ | 0.248 | 0.171 | 0.275 | 3.5 | −0.14 | 26.8 |
+| Pace Chaser Straightaways ◎ | 0.410 | 0.235 | 0.455 | 3.7 | −0.79 | 15.2 |
+| Straightaway Adept | 0.199 | 0.149 | 0.220 | 5.8 | −1.11 | 30.1 |
+| Nimble Navigator | 0.914 | 0.855 | 0.732 | 5.9 | +1.07 | 1.0 |
+| Head-On | 0.772 | 0.734 | 0.583 | 6.0 | +0.83 | 0.0 |
+| Prideful King | 0.403 | 0.154 | 0.452 | 11.4 | −1.90 | 2.6 |
+| Corner Adept ○ | 0.249 | 0.241 | 0.230 | 15.7 | +0.54 | 8.0 |
+| Professor of Curvature | 0.556 | 0.479 | 0.594 | 15.7 | +1.29 | 3.7 |
+| Right-Handed ◎ | 0.147 | 0.277 | 0.000 | 29.4 | −0.89 | 14.0 |
+| Right-Handed ○ | 0.101 | 0.240 | 0.211 | 29.4 | −1.91 | 30.2 |
+| Calm in a Crowd | 0.632 | 1.002 | 0.000 | 54.5 | +1.28 | 0.7 |
+| Corner Recovery ○ | 0.640 | 1.026 | 0.000 | 55.9 | +1.34 | 0.9 |
+
+The gains are bounded (roughly [−4, +7] length), zero-inflated (0% to 56% exact
+zeros from the wisdom check and conditional applicability such as track
+rotation), skewed (−2.2 to +1.3), often extremely leptokurtic (excess kurtosis
+up to ~32), and frequently multimodal (a spike at 0 from non-triggering plus a
+positive bump). The per-race distribution is about as non-normal as it gets.
+
+## Coverage study
+
+Monte-Carlo coverage at n = 500 (target 95%, 800 outer resamples, 600 inner
+bootstrap replicates), treating each 20k sample as the population. Cells are
+`coverage% / mean half-width`.
+
+| skill (%zero, skew) | Wald-z | Hoeffding | Emp. Bernstein | Boot-pct | Boot-BCa |
+| --- | --- | --- | --- | --- | --- |
+| Ignited Spirit (0%, +0.5) | 95.5 / 0.018 | 100 / 0.329 | 100 / 0.138 | 95.1 / 0.018 | 94.5 / 0.018 |
+| Nimble Navigator (6%, +1.1) | 95.6 / 0.075 | 100 / 0.313 | 100 / 0.219 | 95.1 / 0.075 | 95.4 / 0.075 |
+| Professor of Curv. (16%, +1.3) | 94.0 / 0.042 | 100 / 0.367 | 100 / 0.188 | 94.0 / 0.042 | 93.1 / 0.042 |
+| Corner Recovery (56%, +1.3) | 94.0 / 0.090 | 100 / 0.499 | 100 / 0.304 | 93.8 / 0.089 | 94.1 / 0.090 |
+
+Findings:
+
+- The CI is on the mean, not on the per-race gain, so the CLT applies. At
+  n = 500 the Wald interval lands at 94.0% to 95.6% coverage even for the
+  56%-zero, skew-1.3 skills. The grotesque per-race shape does not break the
+  mean interval.
+- Hoeffding and empirical Bernstein deliver their guarantee (100% coverage) at
+  3x to 19x the Wald width. A half-width of 0.3 to 0.5 length on means of 0.2 to
+  0.9 would swamp the signal and make most skills statistically
+  indistinguishable in the table. They also need a known support `[a,b]` that we
+  do not have a priori (the study fed them the population range; in-app only the
+  per-run empirical range is available, which is smaller and silently breaks the
+  guarantee).
+- Bootstrap (percentile and BCa) matches Wald to three digits and is sometimes
+  slightly worse (BCa 93.1% to 95.4%), at 600x the compute. At n = 500 the
+  skew correction BCa exists to provide is already negligible.
+
+## Decision: Student t_{n-1}
+
+Keep the cheap parametric interval, but use the `t_{n-1}` quantile instead of
+the normal `z`. Rationale:
+
+- Among practical options it is the tightest with near-nominal coverage and
+  O(1) compute, which is what a descriptive UI stat needs.
+- The guaranteed-coverage methods cost 3x to 19x width to fix an undercoverage
+  that is about 1 percentage point at n = 500.
+- The bootstrap gives an identical answer for hundreds of times the work.
+- `t` over `z` is the free, marginally more honest choice for small n: at
+  n = 500 the two agree to ~0.2%, and `t` widens correctly when a config runs
+  few simulations or when per-combination batching shrinks the effective n.
+
+Implementation: `tForConfidenceLevel` / `studentTQuantile` in `utils.ts`, used
+by `calculateStatsFromRawResults`. Small df use the exact t-beta identity
+`df/(df+T²) ~ Beta(df/2, 1/2)`; df ≥ 50 (the production regime) use the
+Cornish-Fisher expansion, which is exact to the eye there and avoids the slow
+convergence of the incomplete-beta continued fraction as `x → 1`.
+
+A negative Mean CI bound, if it ever appears, means the true mean is
+statistically indistinguishable from zero. That is correct information and is
+not clamped.

--- a/simulation-runner.test.ts
+++ b/simulation-runner.test.ts
@@ -369,7 +369,7 @@ describe('simulation worker integration', () => {
         expect(stats.meanLength).toBeGreaterThan(0)
         expect(stats.minLength).toBeLessThanOrEqual(stats.meanLength)
         expect(stats.maxLength).toBeGreaterThanOrEqual(stats.meanLength)
-        expect(stats.ciLower).toBeLessThanOrEqual(stats.ciUpper)
+        expect(stats.rangeLower).toBeLessThanOrEqual(stats.rangeUpper)
     }, 30000)
 
     it('all-random scenario should complete without combinatorial explosion', async () => {

--- a/stats-intervals.test.ts
+++ b/stats-intervals.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
     calculateStatsFromRawResults,
     standardNormalQuantile,
+    tForConfidenceLevel,
     zForConfidenceLevel,
 } from './utils'
 
@@ -28,20 +29,39 @@ describe('zForConfidenceLevel', () => {
     })
 })
 
+describe('tForConfidenceLevel', () => {
+    it('matches standard t-table values', () => {
+        expect(tForConfidenceLevel(95, 1)).toBeCloseTo(12.7062, 2)
+        expect(tForConfidenceLevel(95, 5)).toBeCloseTo(2.5706, 3)
+        expect(tForConfidenceLevel(95, 10)).toBeCloseTo(2.2281, 3)
+        expect(tForConfidenceLevel(95, 30)).toBeCloseTo(2.0423, 3)
+        expect(tForConfidenceLevel(95, 100)).toBeCloseTo(1.984, 3)
+        expect(tForConfidenceLevel(99, 10)).toBeCloseTo(3.1693, 3)
+    })
+
+    it('converges to the normal z-score as df grows', () => {
+        expect(tForConfidenceLevel(95, 100000)).toBeCloseTo(
+            zForConfidenceLevel(95),
+            3,
+        )
+    })
+})
+
 describe('calculateStatsFromRawResults confidence interval of the mean', () => {
-    it('computes mean ± z·(s/√n) with the sample standard deviation', () => {
+    it('computes mean ± t·(s/√n) with the sample standard deviation', () => {
         const r = calculateStatsFromRawResults([1, 2, 3, 4, 5], 100, 0, 'X', 95)
-        // mean=3, sample sd=√2.5≈1.5811, SE≈0.70711, z≈1.95996, margin≈1.3859
+        // mean=3, sample sd=√2.5≈1.5811, SE≈0.70711, t_{4,.975}≈2.7764,
+        // margin≈1.9632
         expect(r.meanLength).toBeCloseTo(3, 10)
-        expect(r.ciMeanLower).toBeCloseTo(1.6141, 3)
-        expect(r.ciMeanUpper).toBeCloseTo(4.3859, 3)
+        expect(r.ciMeanLower).toBeCloseTo(1.0368, 3)
+        expect(r.ciMeanUpper).toBeCloseTo(4.9632, 3)
     })
 
     it('is tighter than the percentile range for a spread sample', () => {
         const r = calculateStatsFromRawResults([1, 2, 3, 4, 5], 100, 0, 'X', 95)
         // percentile range spans the extremes here; CI of the mean is inside it
-        expect(r.ciMeanLower).toBeGreaterThan(r.ciLower)
-        expect(r.ciMeanUpper).toBeLessThan(r.ciUpper)
+        expect(r.ciMeanLower).toBeGreaterThan(r.rangeLower)
+        expect(r.ciMeanUpper).toBeLessThan(r.rangeUpper)
     })
 
     it('collapses to the mean for a single sample (zero margin)', () => {
@@ -59,10 +79,10 @@ describe('calculateStatsFromRawResults confidence interval of the mean', () => {
         expect(width99).toBeGreaterThan(width90)
     })
 
-    it('keeps the percentile range as the outcome spread (ciLower/ciUpper)', () => {
+    it('keeps the percentile range as the outcome spread (rangeLower/rangeUpper)', () => {
         const r = calculateStatsFromRawResults([1, 2, 3, 4, 5], 100, 0, 'X', 95)
         // 2.5th percentile index = floor(5*0.025)=0 -> 1; 97.5th = index 4 -> 5
-        expect(r.ciLower).toBe(1)
-        expect(r.ciUpper).toBe(5)
+        expect(r.rangeLower).toBe(1)
+        expect(r.rangeUpper).toBe(5)
     })
 })

--- a/upgrade-cascade.test.ts
+++ b/upgrade-cascade.test.ts
@@ -31,8 +31,8 @@ const freshResult = (skill: string, mean: number): SkillResult => ({
     meanLengthPerCost: mean / 100,
     minLength: 0,
     maxLength: mean * 2,
-    ciLower: 0,
-    ciUpper: mean * 2,
+    rangeLower: 0,
+    rangeUpper: mean * 2,
     ciMeanLower: mean,
     ciMeanUpper: mean,
 })

--- a/utils.test.ts
+++ b/utils.test.ts
@@ -702,7 +702,7 @@ describe('calculateStatsFromRawResults', () => {
         expect(result.medianLength).toBe(2.5)
     })
 
-    it('calculates confidence interval correctly', () => {
+    it('calculates the outcome-spread range correctly', () => {
         const rawResults = Array.from({ length: 100 }, (_, i) => i + 1)
         const result = calculateStatsFromRawResults(
             rawResults,
@@ -712,8 +712,8 @@ describe('calculateStatsFromRawResults', () => {
             95,
         )
 
-        expect(result.ciLower).toBe(3)
-        expect(result.ciUpper).toBe(98)
+        expect(result.rangeLower).toBe(3)
+        expect(result.rangeUpper).toBe(98)
     })
 
     it('handles single result', () => {

--- a/utils.ts
+++ b/utils.ts
@@ -141,10 +141,10 @@ export interface SkillResult {
     maxLength: number
     // Outcome spread: the central percentile band of individual per-race
     // results (e.g. 2.5th–97.5th for 95%). NOT a confidence interval of the
-    // mean. Named ciLower/ciUpper for historical reasons.
-    ciLower: number
-    ciUpper: number
-    // Confidence interval of the MEAN gain (mean ± z·SE): how precisely the
+    // mean.
+    rangeLower: number
+    rangeUpper: number
+    // Confidence interval of the MEAN gain (mean ± t·SE): how precisely the
     // average is estimated.
     ciMeanLower: number
     ciMeanUpper: number
@@ -489,6 +489,142 @@ export function zForConfidenceLevel(ciPercent: number): number {
     return standardNormalQuantile((1 + ciPercent / 100) / 2)
 }
 
+/** Natural log of the gamma function (Lanczos approximation, g=7). */
+function logGamma(x: number): number {
+    const c = [
+        0.99999999999980993, 676.5203681218851, -1259.1392167224028,
+        771.32342877765313, -176.61502916214059, 12.507343278686905,
+        -0.13857109526572012, 9.9843695780195716e-6, 1.5056327351493116e-7,
+    ]
+    if (x < 0.5) {
+        return Math.log(Math.PI / Math.sin(Math.PI * x)) - logGamma(1 - x)
+    }
+    const y = x - 1
+    let a = c[0]!
+    const t = y + 7.5
+    for (let i = 1; i < 9; i++) a += c[i]! / (y + i)
+    return (
+        0.5 * Math.log(2 * Math.PI) + (y + 0.5) * Math.log(t) - t + Math.log(a)
+    )
+}
+
+/** Lentz continued fraction for the incomplete beta (Numerical Recipes). */
+function betaContinuedFraction(x: number, a: number, b: number): number {
+    const MAX_ITER = 1000
+    const EPS = 1e-15
+    const TINY = 1e-300
+    const qab = a + b
+    const qap = a + 1
+    const qam = a - 1
+    let c = 1
+    let d = 1 - (qab * x) / qap
+    if (Math.abs(d) < TINY) d = TINY
+    d = 1 / d
+    let h = d
+    for (let m = 1; m <= MAX_ITER; m++) {
+        const m2 = 2 * m
+        let aa = (m * (b - m) * x) / ((qam + m2) * (a + m2))
+        d = 1 + aa * d
+        if (Math.abs(d) < TINY) d = TINY
+        c = 1 + aa / c
+        if (Math.abs(c) < TINY) c = TINY
+        d = 1 / d
+        h *= d * c
+        aa = (-(a + m) * (qab + m) * x) / ((a + m2) * (qap + m2))
+        d = 1 + aa * d
+        if (Math.abs(d) < TINY) d = TINY
+        c = 1 + aa / c
+        if (Math.abs(c) < TINY) c = TINY
+        d = 1 / d
+        const del = d * c
+        h *= del
+        if (Math.abs(del - 1) < EPS) break
+    }
+    return h
+}
+
+/** Regularized lower incomplete beta I_x(a, b). */
+function regularizedIncompleteBeta(x: number, a: number, b: number): number {
+    if (x <= 0) return 0
+    if (x >= 1) return 1
+    const front = Math.exp(
+        logGamma(a + b) -
+            logGamma(a) -
+            logGamma(b) +
+            a * Math.log(x) +
+            b * Math.log(1 - x),
+    )
+    if (x < (a + 1) / (a + b + 2)) {
+        return (front * betaContinuedFraction(x, a, b)) / a
+    }
+    return 1 - (front * betaContinuedFraction(1 - x, b, a)) / b
+}
+
+/** Inverse of the regularized incomplete beta via bisection. */
+function inverseRegularizedIncompleteBeta(
+    p: number,
+    a: number,
+    b: number,
+): number {
+    if (p <= 0) return 0
+    if (p >= 1) return 1
+    let lo = 0
+    let hi = 1
+    for (let i = 0; i < 80; i++) {
+        const mid = (lo + hi) / 2
+        if (regularizedIncompleteBeta(mid, a, b) < p) {
+            lo = mid
+        } else {
+            hi = mid
+        }
+    }
+    return (lo + hi) / 2
+}
+
+/**
+ * Cornish-Fisher expansion of the t quantile from the normal quantile. Exact to
+ * the eye for large df; used for df >= 50 where the beta continued fraction
+ * converges slowly as x -> 1.
+ */
+function cornishFisherT(p: number, df: number): number {
+    const z = standardNormalQuantile(p)
+    const z3 = z ** 3
+    const z5 = z ** 5
+    const z7 = z ** 7
+    const z9 = z ** 9
+    const g1 = (z3 + z) / 4
+    const g2 = (5 * z5 + 16 * z3 + 3 * z) / 96
+    const g3 = (3 * z7 + 19 * z5 + 17 * z3 - 15 * z) / 384
+    const g4 = (79 * z9 + 776 * z7 + 1482 * z5 - 1920 * z3 - 945 * z) / 92160
+    return z + g1 / df + g2 / df ** 2 + g3 / df ** 3 + g4 / df ** 4
+}
+
+/**
+ * Student's t quantile (inverse CDF) with `df` degrees of freedom. Small df use
+ * the exact t-beta identity df/(df+T^2) ~ Beta(df/2, 1/2); large df use the
+ * Cornish-Fisher expansion. Converges to the normal quantile as df grows.
+ */
+export function studentTQuantile(p: number, df: number): number {
+    if (p <= 0 || p >= 1) {
+        throw new Error(`studentTQuantile expects p in (0,1), got ${p}`)
+    }
+    if (df <= 0) {
+        throw new Error(`studentTQuantile expects df > 0, got ${df}`)
+    }
+    if (p === 0.5) return 0
+    if (df >= 50) return cornishFisherT(p, df)
+    const upper = p > 0.5
+    const tail = upper ? 1 - p : p
+    const x = inverseRegularizedIncompleteBeta(2 * tail, df / 2, 0.5)
+    const t = Math.sqrt((df * (1 - x)) / x)
+    return upper ? t : -t
+}
+
+/** Two-sided t-score for a confidence level (percentage) at `df` degrees of freedom. */
+export function tForConfidenceLevel(ciPercent: number, df: number): number {
+    return studentTQuantile((1 + ciPercent / 100) / 2, df)
+}
+
 export function calculateStatsFromRawResults(
     rawResults: number[],
     cost: number,
@@ -515,19 +651,25 @@ export function calculateStatsFromRawResults(
         Math.floor(sorted.length * (upperPercentile / 100)),
         sorted.length - 1,
     )
-    const ciLower = sorted[lowerIndex]!
-    const ciUpper = sorted[upperIndex]!
+    const rangeLower = sorted[lowerIndex]!
+    const rangeUpper = sorted[upperIndex]!
     const meanLengthPerCost = cost > 0 ? mean / cost : 0
 
-    // Confidence interval of the mean: mean ± z·(s/√n), using the sample
-    // standard deviation (n-1). With a single sample the margin is 0.
+    // Confidence interval of the mean: mean ± t_{n-1}·(s/√n), using the sample
+    // standard deviation (n-1). Bounded data is never exactly normal, so the t
+    // pivot is (like z) only asymptotically exact, but it is marginally more
+    // honest at small n and converges to z as n grows. A single sample has
+    // SE = 0, so the margin is 0 and the degrees of freedom are never evaluated.
     const variance =
         sorted.length > 1
             ? sorted.reduce((acc, v) => acc + (v - mean) ** 2, 0) /
               (sorted.length - 1)
             : 0
     const standardError = Math.sqrt(variance) / Math.sqrt(sorted.length)
-    const margin = zForConfidenceLevel(ciPercent) * standardError
+    const margin =
+        sorted.length > 1
+            ? tForConfidenceLevel(ciPercent, sorted.length - 1) * standardError
+            : 0
 
     return {
         skill: skillName,
@@ -538,8 +680,8 @@ export function calculateStatsFromRawResults(
         meanLengthPerCost,
         minLength: min,
         maxLength: max,
-        ciLower,
-        ciUpper,
+        rangeLower,
+        rangeUpper,
         ciMeanLower: mean - margin,
         ciMeanUpper: mean + margin,
     }


### PR DESCRIPTION
## Persist & restore the last results per config

Results lived only in memory, so reloading the page showed an empty table until
you clicked Run again. This persists each config's last calculated results to a
new IndexedDB store and restores them on load, so they reappear **instantly with
no recomputation** and no staleness indicator (as requested).

### Behaviour

- On config load, the in-memory results are cleared and rehydrated from the
  store. This also fixes a previous config's results lingering after a switch —
  results are now scoped per config.
- Saving is debounced off the table render, so both a full run and post-run edits
  are captured.
- **Duplicating a config** copies its cached results too, so the duplicate opens
  with the same table immediately.
- Persisted results are dropped when a config is deleted or replaced by an import
  (an import replaces the config, so its old results no longer describe it).
- A new `results` object store (DB version 1 → 2) holds plain `SkillResult[]`
  keyed by config name; restored rows render as `cached`.
- A render-results callback (mirroring the existing uma/skills ones) lets
  `configManager` trigger a results re-render without importing `resultsUI`.

### Verified (headless browser)

- **Reload:** ran a calculation with no seed, captured the top row, reloaded, and
  the row was byte-identical. Since an unseeded recompute would differ, identical
  values prove the table was *restored, not recomputed*. Run button enabled on
  load, results shown immediately, no console errors.
- **Duplicate:** ran on a config (no seed), duplicated it, and the duplicate
  opened with byte-identical results — proving the cache was copied, not
  recomputed.

`npm test` green, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
